### PR TITLE
add MSA and GLA operators

### DIFF
--- a/benchmark/chunk_gla_benchmark.py
+++ b/benchmark/chunk_gla_benchmark.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Forward and backward benchmark for chunked gated linear attention."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import triton
+
+from flag_attn.gated_linear_attention import chunk_gla as flag_attn_chunk_gla
+
+DEFAULT_WARMUP = 100
+DEFAULT_REP = 200
+
+# optional FLA reference
+_HAS_FLA_CHUNK = False
+_fla_chunk_gla = None
+
+try:
+    from fla.ops.gla import chunk_gla as _fla_chunk_gla
+
+    _HAS_FLA_CHUNK = True
+except Exception:
+    _HAS_FLA_CHUNK = False
+
+
+def _fla_chunk_wrapper(q, k, v, g, **kwargs):
+    if not _HAS_FLA_CHUNK:
+        raise RuntimeError("fla chunk_gla is unavailable")
+
+    return _fla_chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=kwargs.get("scale", None),
+        initial_state=kwargs.get("initial_state", None),
+        output_final_state=kwargs.get("output_final_state", False),
+        state_v_first=kwargs.get("state_v_first", False),
+        cu_seqlens=kwargs.get("cu_seqlens", None),
+    )
+
+
+def _precompile():
+    """
+    Force:
+    1. Triton JIT compile
+    2. autotune cache population
+    3. CUDA context stabilization
+    """
+    print("[precompile] warming up kernels & autotune cache ...")
+
+    device = torch.device("cuda")
+    dtype = torch.float16
+
+    B, T, H, D = 1, 512, 8, 64
+
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    v = torch.randn(B, T, H, D, device=device, dtype=dtype)
+    g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
+
+    kwargs = {
+        "scale": D**-0.5,
+        "initial_state": None,
+        "output_final_state": False,
+        "state_v_first": False,
+        "cu_seqlens": None,
+        "cu_seqlens_cpu": None,
+    }
+
+    # run multiple times to fully warm autotune
+    for _ in range(5):
+        if _HAS_FLA_CHUNK:
+            _fla_chunk_wrapper(q, k, v, g, **kwargs)
+        flag_attn_chunk_gla(q, k, v, g, **kwargs)
+
+    torch.cuda.synchronize()
+
+
+def _bench_ms(fn, warmup: int, rep: int) -> float:
+    return triton.testing.do_bench(
+        fn,
+        warmup=warmup,
+        rep=rep,
+        return_mode="median",
+    )
+
+
+def _build_inputs(B, T, H, D, dtype, requires_grad=False):
+    device = torch.device("cuda")
+    q = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    k = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    v = torch.randn(B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad)
+    g_logit = torch.randn(
+        B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad
+    )
+
+    kwargs = {
+        "scale": D**-0.5,
+        "initial_state": None,
+        "output_final_state": False,
+        "state_v_first": False,
+        "cu_seqlens": None,
+        "cu_seqlens_cpu": None,
+    }
+    if requires_grad:
+        return q, k, v, g_logit, kwargs
+    else:
+        g = F.logsigmoid(g_logit)
+        return q, k, v, g, kwargs
+
+
+# ---------------------------
+# fwd+bwd benchmark helper
+# ---------------------------
+def _bench_fwd_bwd_ms(fn, q, k, v, g_logit, kwargs, warmup: int, rep: int) -> float:
+    """Measure forward + backward pass time for a chunk_gla function.
+
+    ``g_logit`` is the pre-logsigmoid raw tensor (a leaf).  F.logsigmoid is
+    called *inside* the timed closure so each backward iteration gets a fresh
+    computation graph.
+    """
+
+    params = [q, k, v, g_logit]
+
+    def _fwd_bwd():
+        for p in params:
+            if p.grad is not None:
+                p.grad.zero_()
+        g = F.logsigmoid(g_logit)
+        out = fn(q, k, v, g, **kwargs)
+        if isinstance(out, tuple):
+            out = out[0]
+        loss = out.sum()
+        loss.backward()
+
+    return triton.testing.do_bench(
+        _fwd_bwd,
+        warmup=warmup,
+        rep=rep,
+        return_mode="median",
+    )
+
+
+_SHAPES = [
+    # (1, 4096, 32, 512),
+    # (2, 2048, 16, 512),
+    (1, 8192, 96, 128),
+    (2, 16384, 16, 128),
+    (4, 2048, 16, 128),
+    (4, 4096, 64, 128),
+    (8, 2048, 32, 256),
+    (2, 2048, 16, 512),
+    (4, 1024, 8, 512),
+    (8, 1024, 8, 64),
+]
+
+_DTYPES = [
+    torch.bfloat16,
+    # torch.float32,
+    # torch.float16,
+]
+
+
+def _print_header(title: str, subtitle: str, warmup: int, rep: int) -> None:
+    print(f"\n{'=' * 70}")
+    print(f"  {title}")
+    print(f"  {subtitle}")
+    print(f"  warmup={warmup}ms  rep={rep}ms")
+    print(f"{'=' * 70}")
+
+    if _HAS_FLA_CHUNK:
+        print(
+            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
+            f"{'fla(ms)':>10} {'flag_attn(ms)':>14} {'fla/flag_attn':>14}"
+        )
+    else:
+        print(
+            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
+            f"{'flag_attn(ms)':>14}"
+        )
+
+
+def _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn) -> None:
+    dtype_str = str(dtype).split(".")[-1]
+    if _HAS_FLA_CHUNK:
+        speedup = ms_fla / ms_flag_attn if ms_flag_attn > 0 else float("inf")
+        print(
+            f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} "
+            f"{ms_fla:>10.3f} {ms_flag_attn:>14.3f} {speedup:>14.2f}x"
+        )
+    else:
+        print(
+            f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} "
+            f"{ms_flag_attn:>14.3f}"
+        )
+
+
+# ---------------------------
+# unified benchmark (fwd then fwd+bwd)
+# ---------------------------
+def run_benchmark(warmup: int = DEFAULT_WARMUP, rep: int = DEFAULT_REP) -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("chunk_gla benchmark requires CUDA")
+
+    # ============================================================
+    # Part 1: forward only
+    # ============================================================
+    _print_header(
+        "chunk_gla benchmark — FWD ONLY",
+        "provider: fla_chunk vs flag_attn_chunk",
+        warmup,
+        rep,
+    )
+
+    _precompile()
+    torch.cuda.synchronize()
+
+    for dtype in _DTYPES:
+        print("\ndtype:", dtype)
+        for B, T, H, D in _SHAPES:
+            q, k, v, g, kwargs = _build_inputs(B, T, H, D, dtype)
+
+            ms_fla = None
+            if _HAS_FLA_CHUNK:
+                ms_fla = _bench_ms(
+                    lambda: _fla_chunk_wrapper(q, k, v, g, **kwargs), warmup, rep
+                )
+            ms_flag_attn = _bench_ms(
+                lambda: flag_attn_chunk_gla(q, k, v, g, **kwargs), warmup, rep
+            )
+            _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn)
+
+    # ============================================================
+    # Part 2: forward + backward
+    # ============================================================
+    _print_header(
+        "chunk_gla benchmark — FWD + BWD",
+        "provider: fla_chunk vs flag_attn_chunk  (forward + backward)",
+        warmup,
+        rep,
+    )
+
+    # warmup: run fwd+bwd on a small shape so backward kernels compile
+    print("[precompile] warming up fwd+bwd kernels ...")
+    wq, wk, wv, wg_logit, wkwargs = _build_inputs(
+        1, 256, 4, 64, torch.float16, requires_grad=True
+    )
+    for _ in range(3):
+        if _HAS_FLA_CHUNK:
+            wg = F.logsigmoid(wg_logit)
+            out = _fla_chunk_wrapper(wq, wk, wv, wg, **wkwargs)
+            if isinstance(out, tuple):
+                out = out[0]
+            out.sum().backward()
+            for p in [wq, wk, wv, wg_logit]:
+                if p.grad is not None:
+                    p.grad.zero_()
+        wg = F.logsigmoid(wg_logit)
+        out = flag_attn_chunk_gla(wq, wk, wv, wg, **wkwargs)
+        if isinstance(out, tuple):
+            out = out[0]
+        out.sum().backward()
+        for p in [wq, wk, wv, wg_logit]:
+            if p.grad is not None:
+                p.grad.zero_()
+    torch.cuda.synchronize()
+
+    for dtype in _DTYPES:
+        print("\ndtype:", dtype)
+        for B, T, H, D in _SHAPES:
+            q, k, v, g_logit, kwargs = _build_inputs(
+                B, T, H, D, dtype, requires_grad=True
+            )
+
+            ms_fla = None
+            if _HAS_FLA_CHUNK:
+                ms_fla = _bench_fwd_bwd_ms(
+                    _fla_chunk_wrapper,
+                    q,
+                    k,
+                    v,
+                    g_logit,
+                    kwargs,
+                    warmup,
+                    rep,
+                )
+            ms_flag_attn = _bench_fwd_bwd_ms(
+                flag_attn_chunk_gla,
+                q,
+                k,
+                v,
+                g_logit,
+                kwargs,
+                warmup,
+                rep,
+            )
+            _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn)
+
+    print(f"\n{'=' * 70}")
+    print("  All done. ")
+    print(f"{'=' * 70}\n")
+
+
+def test_chunk_gla_benchmark() -> None:
+    """Allow explicit execution through pytest with default timings."""
+    run_benchmark()

--- a/benchmark/chunk_gla_benchmark.py
+++ b/benchmark/chunk_gla_benchmark.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2026 FlagOS Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Forward and backward benchmark for chunked gated linear attention."""
-
-from __future__ import annotations
-
 import torch
 import torch.nn.functional as F
 import triton
 
 from flag_attn.gated_linear_attention import chunk_gla as flag_attn_chunk_gla
 
-DEFAULT_WARMUP = 100
-DEFAULT_REP = 200
 
 # optional FLA reference
 _HAS_FLA_CHUNK = False
@@ -39,9 +32,6 @@ except Exception:
 
 
 def _fla_chunk_wrapper(q, k, v, g, **kwargs):
-    if not _HAS_FLA_CHUNK:
-        raise RuntimeError("fla chunk_gla is unavailable")
-
     return _fla_chunk_gla(
         q=q,
         k=k,
@@ -55,26 +45,8 @@ def _fla_chunk_wrapper(q, k, v, g, **kwargs):
     )
 
 
-def _precompile():
-    """
-    Force:
-    1. Triton JIT compile
-    2. autotune cache population
-    3. CUDA context stabilization
-    """
-    print("[precompile] warming up kernels & autotune cache ...")
-
-    device = torch.device("cuda")
-    dtype = torch.float16
-
-    B, T, H, D = 1, 512, 8, 64
-
-    q = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    k = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    v = torch.randn(B, T, H, D, device=device, dtype=dtype)
-    g = F.logsigmoid(torch.randn(B, T, H, D, device=device, dtype=dtype))
-
-    kwargs = {
+def _make_kwargs(D: int) -> dict:
+    return {
         "scale": D**-0.5,
         "initial_state": None,
         "output_final_state": False,
@@ -82,23 +54,6 @@ def _precompile():
         "cu_seqlens": None,
         "cu_seqlens_cpu": None,
     }
-
-    # run multiple times to fully warm autotune
-    for _ in range(5):
-        if _HAS_FLA_CHUNK:
-            _fla_chunk_wrapper(q, k, v, g, **kwargs)
-        flag_attn_chunk_gla(q, k, v, g, **kwargs)
-
-    torch.cuda.synchronize()
-
-
-def _bench_ms(fn, warmup: int, rep: int) -> float:
-    return triton.testing.do_bench(
-        fn,
-        warmup=warmup,
-        rep=rep,
-        return_mode="median",
-    )
 
 
 def _build_inputs(B, T, H, D, dtype, requires_grad=False):
@@ -110,24 +65,13 @@ def _build_inputs(B, T, H, D, dtype, requires_grad=False):
         B, T, H, D, device=device, dtype=dtype, requires_grad=requires_grad
     )
 
-    kwargs = {
-        "scale": D**-0.5,
-        "initial_state": None,
-        "output_final_state": False,
-        "state_v_first": False,
-        "cu_seqlens": None,
-        "cu_seqlens_cpu": None,
-    }
     if requires_grad:
-        return q, k, v, g_logit, kwargs
+        return q, k, v, g_logit
     else:
         g = F.logsigmoid(g_logit)
-        return q, k, v, g, kwargs
+        return q, k, v, g
 
 
-# ---------------------------
-# fwd+bwd benchmark helper
-# ---------------------------
 def _bench_fwd_bwd_ms(fn, q, k, v, g_logit, kwargs, warmup: int, rep: int) -> float:
     """Measure forward + backward pass time for a chunk_gla function.
 
@@ -157,7 +101,11 @@ def _bench_fwd_bwd_ms(fn, q, k, v, g_logit, kwargs, warmup: int, rep: int) -> fl
     )
 
 
+DEFAULT_WARMUP = 100
+DEFAULT_REP = 200
+
 _SHAPES = [
+    # (B, T, H, D)
     # (1, 4096, 32, 512),
     # (2, 2048, 16, 512),
     (1, 8192, 96, 128),
@@ -170,153 +118,56 @@ _SHAPES = [
     (8, 1024, 8, 64),
 ]
 
-_DTYPES = [
+_T_DTYPES = [
     torch.bfloat16,
     # torch.float32,
     # torch.float16,
 ]
 
+configs = [
+    triton.testing.Benchmark(
+        x_names=["shape"],
+        x_vals=[(B, T, H, D) for B, T, H, D in _SHAPES],
+        line_arg="provider",
+        line_vals=["flag_attn"] + (["fla"] if _HAS_FLA_CHUNK else []),
+        line_names=["flag_attn"] + (["fla"] if _HAS_FLA_CHUNK else []),
+        styles=[("red", "-"), ("blue", "-")],
+        ylabel="ms",
+        plot_name=f"chunk_gla-mode-{mode}-dtype-{dtype}",
+        args={"mode": mode, "dtype": dtype},
+    )
+    for mode in ["fwd", "bwd"]
+    for dtype in _T_DTYPES
+]
 
-def _print_header(title: str, subtitle: str, warmup: int, rep: int) -> None:
-    print(f"\n{'=' * 70}")
-    print(f"  {title}")
-    print(f"  {subtitle}")
-    print(f"  warmup={warmup}ms  rep={rep}ms")
-    print(f"{'=' * 70}")
 
-    if _HAS_FLA_CHUNK:
-        print(
-            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
-            f"{'fla(ms)':>10} {'flag_attn(ms)':>14} {'fla/flag_attn':>14}"
-        )
+@triton.testing.perf_report(configs)
+def bench_chunk_gla(shape, mode, provider, dtype=torch.bfloat16, device="cuda"):
+    assert mode in ["fwd", "bwd"]
+    B, T, H, D = shape
+
+    is_bwd = mode == "bwd"
+    kwargs = _make_kwargs(D)
+
+    if provider == "flag_attn":
+        fn = flag_attn_chunk_gla
+    elif provider == "fla":
+        fn = _fla_chunk_wrapper
     else:
-        print(
-            f"{'B':>3} {'T':>6} {'H':>4} {'D':>4} {'dtype':>8} "
-            f"{'flag_attn(ms)':>14}"
-        )
+        raise ValueError(f"unknown provider: {provider}")
 
-
-def _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn) -> None:
-    dtype_str = str(dtype).split(".")[-1]
-    if _HAS_FLA_CHUNK:
-        speedup = ms_fla / ms_flag_attn if ms_flag_attn > 0 else float("inf")
-        print(
-            f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} "
-            f"{ms_fla:>10.3f} {ms_flag_attn:>14.3f} {speedup:>14.2f}x"
-        )
+    if is_bwd:
+        q, k, v, g_logit = _build_inputs(B, T, H, D, dtype, requires_grad=True)
+        ms = _bench_fwd_bwd_ms(fn, q, k, v, g_logit, kwargs, DEFAULT_WARMUP, DEFAULT_REP)
     else:
-        print(
-            f"{B:>3} {T:>6} {H:>4} {D:>4} {dtype_str:>8} "
-            f"{ms_flag_attn:>14.3f}"
+        q, k, v, g = _build_inputs(B, T, H, D, dtype, requires_grad=False)
+        ms = triton.testing.do_bench(
+            lambda: fn(q, k, v, g, **kwargs), warmup=DEFAULT_WARMUP, rep=DEFAULT_REP
         )
 
-
-# ---------------------------
-# unified benchmark (fwd then fwd+bwd)
-# ---------------------------
-def run_benchmark(warmup: int = DEFAULT_WARMUP, rep: int = DEFAULT_REP) -> None:
-    if not torch.cuda.is_available():
-        raise RuntimeError("chunk_gla benchmark requires CUDA")
-
-    # ============================================================
-    # Part 1: forward only
-    # ============================================================
-    _print_header(
-        "chunk_gla benchmark — FWD ONLY",
-        "provider: fla_chunk vs flag_attn_chunk",
-        warmup,
-        rep,
-    )
-
-    _precompile()
-    torch.cuda.synchronize()
-
-    for dtype in _DTYPES:
-        print("\ndtype:", dtype)
-        for B, T, H, D in _SHAPES:
-            q, k, v, g, kwargs = _build_inputs(B, T, H, D, dtype)
-
-            ms_fla = None
-            if _HAS_FLA_CHUNK:
-                ms_fla = _bench_ms(
-                    lambda: _fla_chunk_wrapper(q, k, v, g, **kwargs), warmup, rep
-                )
-            ms_flag_attn = _bench_ms(
-                lambda: flag_attn_chunk_gla(q, k, v, g, **kwargs), warmup, rep
-            )
-            _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn)
-
-    # ============================================================
-    # Part 2: forward + backward
-    # ============================================================
-    _print_header(
-        "chunk_gla benchmark — FWD + BWD",
-        "provider: fla_chunk vs flag_attn_chunk  (forward + backward)",
-        warmup,
-        rep,
-    )
-
-    # warmup: run fwd+bwd on a small shape so backward kernels compile
-    print("[precompile] warming up fwd+bwd kernels ...")
-    wq, wk, wv, wg_logit, wkwargs = _build_inputs(
-        1, 256, 4, 64, torch.float16, requires_grad=True
-    )
-    for _ in range(3):
-        if _HAS_FLA_CHUNK:
-            wg = F.logsigmoid(wg_logit)
-            out = _fla_chunk_wrapper(wq, wk, wv, wg, **wkwargs)
-            if isinstance(out, tuple):
-                out = out[0]
-            out.sum().backward()
-            for p in [wq, wk, wv, wg_logit]:
-                if p.grad is not None:
-                    p.grad.zero_()
-        wg = F.logsigmoid(wg_logit)
-        out = flag_attn_chunk_gla(wq, wk, wv, wg, **wkwargs)
-        if isinstance(out, tuple):
-            out = out[0]
-        out.sum().backward()
-        for p in [wq, wk, wv, wg_logit]:
-            if p.grad is not None:
-                p.grad.zero_()
-    torch.cuda.synchronize()
-
-    for dtype in _DTYPES:
-        print("\ndtype:", dtype)
-        for B, T, H, D in _SHAPES:
-            q, k, v, g_logit, kwargs = _build_inputs(
-                B, T, H, D, dtype, requires_grad=True
-            )
-
-            ms_fla = None
-            if _HAS_FLA_CHUNK:
-                ms_fla = _bench_fwd_bwd_ms(
-                    _fla_chunk_wrapper,
-                    q,
-                    k,
-                    v,
-                    g_logit,
-                    kwargs,
-                    warmup,
-                    rep,
-                )
-            ms_flag_attn = _bench_fwd_bwd_ms(
-                flag_attn_chunk_gla,
-                q,
-                k,
-                v,
-                g_logit,
-                kwargs,
-                warmup,
-                rep,
-            )
-            _print_row(B, T, H, D, dtype, ms_fla, ms_flag_attn)
-
-    print(f"\n{'=' * 70}")
-    print("  All done. ")
-    print(f"{'=' * 70}\n")
+    # Return raw latency in ms, matching the original benchmark semantics.
+    return ms
 
 
-def test_chunk_gla_benchmark() -> None:
-    """Allow explicit execution through pytest with default timings."""
-    run_benchmark()
+# only works on post-Ampere GPUs right now
+bench_chunk_gla.run(print_data=True)

--- a/benchmark/minimax_sparse_attention_benchmark.py
+++ b/benchmark/minimax_sparse_attention_benchmark.py
@@ -1,28 +1,12 @@
-#!/usr/bin/env python3
-# Copyright 2026 FlagOS Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """CUDA benchmark for the MiniMax M3 paged MSA kernels.
 
-The benchmark compares the FlagAttention and vLLM implementations on the same
+The benchmark compares the FlagGems and vLLM implementations on the same
 inputs.  ``fp8`` means FP8 index queries/index keys and FP8 main KV cache,
 with scalar K/V dequantization scales passed to both implementations.
 """
 
 from __future__ import annotations
 
-import argparse
 import inspect
 import sys
 import warnings
@@ -80,13 +64,13 @@ class _CachedPlatform:
         return self._supports_pdl
 
 
-_flag_attn_index_module = sys.modules[minimax_m3_index_decode.__module__]
-_flag_attn_sparse_module = sys.modules[minimax_m3_sparse_attn_decode.__module__]
-_flag_attn_platform = _CachedPlatform(
-    _flag_attn_index_module.current_platform.is_arch_support_pdl()
+_flaggems_index_module = sys.modules[minimax_m3_index_decode.__module__]
+_flaggems_sparse_module = sys.modules[minimax_m3_sparse_attn_decode.__module__]
+_flaggems_platform = _CachedPlatform(
+    _flaggems_index_module.current_platform.is_arch_support_pdl()
 )
-_flag_attn_index_module.current_platform = _flag_attn_platform
-_flag_attn_sparse_module.current_platform = _flag_attn_platform
+_flaggems_index_module.current_platform = _flaggems_platform
+_flaggems_sparse_module.current_platform = _flaggems_platform
 
 if VLLM_AVAILABLE:
     _vllm_index_module = sys.modules[vllm_index_decode.__module__]
@@ -108,12 +92,10 @@ KV_SCALE = 0.5
 PREFILL_SHAPES = [
     (1, 8192, 16, 96),
     (2, 16384, 8, 96),
-    (4, 2048, 16, 96),
+    (1, 32768, 16, 96),
+    (2, 8192, 8, 96),
     (4, 4096, 16, 384),
-    (8, 2048, 32, 192),
-    (2, 2048, 16, 96),
-    (4, 1024, 8, 96),
-    (8, 1024, 8, 48),
+    (4, 4096, 16, 256),
 ]
 
 DECODE_SHAPES = [
@@ -126,6 +108,26 @@ DECODE_SHAPES = [
     (32, 2048, 4, 48),
     (64, 1024, 4, 48),
 ]
+
+
+@dataclass
+class MSABenchmarkArgs:
+    dtype: str = "both"
+    shape: str | None = None
+    topk: int = 16
+    init_blocks: int = 1
+    local_blocks: int = 2
+    all_shapes: bool = False
+    per_step: bool = True
+    identity_pages: bool = False
+    prefill_only: bool = False
+    decode_only: bool = False
+    decode_qlen: int = 1
+    warmup: int = DEFAULT_WARMUP
+    rep: int = DEFAULT_REP
+    seed: int = 0
+    no_vllm: bool = False
+    decode: bool = False
 
 
 @dataclass
@@ -260,6 +262,10 @@ def make_data(
     physical_pages = torch.randperm(total_blocks, device=device, generator=generator)
     if not randomize_pages:
         physical_pages = torch.arange(total_blocks, device=device)
+    # Force identity page ordering for FP8 inputs.
+    if dtype_name == "fp8":
+        physical_pages = torch.arange(total_blocks, device=device)
+        randomize_pages = False  # Skip the page-remapping step below.
     block_table = physical_pages.reshape(batch, blocks_per_request).to(torch.int32)
     if randomize_pages:
         kv_cache = kv_cache[physical_pages.argsort()].contiguous()
@@ -441,7 +447,7 @@ def _supports_fp8_scales() -> bool:
 def _bench_steps(
     data: MSAData,
     decode: bool,
-    args: argparse.Namespace,
+    args: MSABenchmarkArgs,
     shape: tuple[int, int, int, int],
 ) -> dict[str, float]:
     batch, seq_len, num_kv_heads, _ = shape
@@ -554,7 +560,7 @@ def _parse_shape(value: str) -> tuple[int, int, int, int]:
     return shape
 
 
-def _get_shapes(args: argparse.Namespace) -> list[tuple[int, int, int, int]]:
+def _get_shapes(args: MSABenchmarkArgs) -> list[tuple[int, int, int, int]]:
     if args.shape is not None and not args.all_shapes:
         return [_parse_shape(args.shape)]
     return DECODE_SHAPES if args.decode else PREFILL_SHAPES
@@ -564,14 +570,15 @@ def _format_columns(columns: list[tuple[str, int]]) -> str:
     return "  ".join(f"{value:>{width}s}" for value, width in columns)
 
 
-def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
+def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
     run_vllm = VLLM_AVAILABLE and not args.no_vllm
     if dtype_name == "fp8" and run_vllm and not _supports_fp8_scales():
         print("[baseline] vLLM FP8 skipped: k_scale/v_scale are unavailable")
         run_vllm = False
 
     mode = f"decode qlen={args.decode_qlen}" if args.decode else "prefill"
-    page_mode = "identity" if args.identity_pages else "random"
+    use_identity_pages = args.identity_pages or dtype_name == "fp8"
+    page_mode = "identity" if use_identity_pages else "random"
     print(f"\nMiniMax M3 paged sparse attention ({mode})")
     print(
         f"dtype={dtype_name}, topk={args.topk}, "
@@ -583,9 +590,9 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
     if run_vllm:
         print("Provider order: alternates by shape")
     else:
-        print("vLLM baseline: unavailable; FlagAttention only")
+        print("vLLM baseline: unavailable; FlagGems only")
 
-    headers = [("Shape [B,S,KVH,H]", 22), ("FlagAttn(ms)", 13)]
+    headers = [("Shape [B,S,KVH,H]", 22), ("FlagGems(ms)", 13)]
     if run_vllm:
         headers.extend([("vLLM(ms)", 10), ("vLLM/ours", 10)])
     if args.per_step:
@@ -622,13 +629,13 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
             dtype_name,
             decode=args.decode,
             decode_qlen=args.decode_qlen,
-            randomize_pages=not args.identity_pages,
+            randomize_pages=not use_identity_pages,
             generator=generator,
         )
-        flag_attn_output = torch.empty_like(data.q)
+        flaggems_output = torch.empty_like(data.q)
         vllm_output = torch.empty_like(data.q) if run_vllm else None
 
-        def flag_attn_run() -> None:
+        def flaggems_run() -> None:
             if args.decode:
                 run_decode(
                     minimax_m3_index_decode,
@@ -640,7 +647,7 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
                     args.init_blocks,
                     args.local_blocks,
                     args.decode_qlen,
-                    flag_attn_output,
+                    flaggems_output,
                 )
             else:
                 run_prefill(
@@ -653,7 +660,7 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
                     args.topk,
                     args.init_blocks,
                     args.local_blocks,
-                    flag_attn_output,
+                    flaggems_output,
                 )
 
         def vllm_run() -> None:
@@ -687,28 +694,28 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
 
         if run_vllm:
             providers = (
-                (("flag_attn", flag_attn_run), ("vllm", vllm_run))
+                (("flaggems", flaggems_run), ("vllm", vllm_run))
                 if shape_index % 2 == 0
-                else (("vllm", vllm_run), ("flag_attn", flag_attn_run))
+                else (("vllm", vllm_run), ("flaggems", flaggems_run))
             )
             timings = {
                 name: bench_fn(fn, args.warmup, args.rep) for name, fn in providers
             }
-            flag_attn_ms = timings["flag_attn"]
+            flaggems_ms = timings["flaggems"]
             vllm_ms = timings["vllm"]
         else:
-            flag_attn_ms = bench_fn(flag_attn_run, args.warmup, args.rep)
+            flaggems_ms = bench_fn(flaggems_run, args.warmup, args.rep)
 
         steps = _bench_steps(data, args.decode, args, shape) if args.per_step else {}
         row = [
             (f"{batch}x{seq_len}x{num_kv_heads}x{num_heads}", 22),
-            (f"{flag_attn_ms:.4f}", 13),
+            (f"{flaggems_ms:.4f}", 13),
         ]
         if run_vllm:
             row.extend(
                 [
                     (f"{vllm_ms:.4f}", 10),
-                    (f"{vllm_ms / flag_attn_ms:.2f}x", 10),
+                    (f"{vllm_ms / flaggems_ms:.2f}x", 10),
                 ]
             )
         if args.per_step:
@@ -731,31 +738,10 @@ def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
         sys.stdout.flush()
 
 
-def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--dtype", choices=("bf16", "fp8", "both"), default="bf16")
-    parser.add_argument("--shape", default=None)
-    parser.add_argument("--topk", type=int, default=32)
-    parser.add_argument("--init-blocks", type=int, default=1)
-    parser.add_argument("--local-blocks", type=int, default=2)
-    parser.add_argument("--all-shapes", action="store_true")
-    parser.add_argument("--per-step", action="store_true")
-    parser.add_argument("--identity-pages", action="store_true")
-    mode = parser.add_mutually_exclusive_group()
-    mode.add_argument("--prefill-only", action="store_true")
-    mode.add_argument(
-        "--decode-only", "--decode", dest="decode_only", action="store_true"
-    )
-    parser.add_argument("--decode-qlen", type=int, default=1)
-    parser.add_argument("--warmup", type=int, default=DEFAULT_WARMUP)
-    parser.add_argument("--rep", type=int, default=DEFAULT_REP)
-    parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--no-vllm", action="store_true")
-    return parser.parse_args(argv)
-
-
-def run_benchmark(args: argparse.Namespace) -> None:
+def run_benchmark(args: MSABenchmarkArgs) -> None:
     _require_cuda()
+    if args.topk < 1:
+        raise ValueError("--topk must be positive")
     if args.decode_qlen < 1:
         raise ValueError("--decode-qlen must be positive")
     if args.warmup < 0 or args.rep <= 0:
@@ -796,16 +782,11 @@ def run_benchmark(args: argparse.Namespace) -> None:
             _run_dtype(args, dtype_name)
 
 
-def test_msa_benchmark() -> None:
-    """Run the MSA benchmark through pytest with default timing options."""
-    args = parse_args([])
-    args.per_step = True
+def test_msa_benchmark(request) -> None:
+    """Run the MSA benchmark through pytest using benchmark CLI timing options."""
+    args = MSABenchmarkArgs(
+        topk=int(request.config.getoption("--topk", default=16)),
+        warmup=int(request.config.getoption("--warmup", default=DEFAULT_WARMUP)),
+        rep=int(request.config.getoption("--iter", default=DEFAULT_REP)),
+    )
     run_benchmark(args)
-
-
-def main() -> None:
-    run_benchmark(parse_args())
-
-
-if __name__ == "__main__":
-    main()

--- a/benchmark/minimax_sparse_attention_benchmark.py
+++ b/benchmark/minimax_sparse_attention_benchmark.py
@@ -1,0 +1,811 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUDA benchmark for the MiniMax M3 paged MSA kernels.
+
+The benchmark compares the FlagAttention and vLLM implementations on the same
+inputs.  ``fp8`` means FP8 index queries/index keys and FP8 main KV cache,
+with scalar K/V dequantization scales passed to both implementations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import inspect
+import sys
+import warnings
+from dataclasses import dataclass
+from typing import Callable
+
+import torch
+import triton
+import triton.knobs
+import triton.testing as triton_testing
+
+from flag_attn.minimax_sparse_attention import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_index_decode,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+    minimax_m3_sparse_attn,
+    minimax_m3_sparse_attn_decode,
+)
+
+try:
+    from vllm.models.minimax_m3.common.ops.index_topk import (
+        minimax_m3_index_decode as vllm_index_decode,
+    )
+    from vllm.models.minimax_m3.common.ops.index_topk import (
+        minimax_m3_index_score as vllm_index_score,
+    )
+    from vllm.models.minimax_m3.common.ops.index_topk import (
+        minimax_m3_index_topk as vllm_index_topk,
+    )
+    from vllm.models.minimax_m3.common.ops.sparse_attn import (
+        minimax_m3_sparse_attn as vllm_sparse_attn,
+    )
+    from vllm.models.minimax_m3.common.ops.sparse_attn import (
+        minimax_m3_sparse_attn_decode as vllm_sparse_attn_decode,
+    )
+
+    VLLM_AVAILABLE = True
+    VLLM_IMPORT_ERROR = ""
+except Exception as exc:  # vLLM is an optional benchmark baseline.
+    VLLM_AVAILABLE = False
+    VLLM_IMPORT_ERROR = f"{type(exc).__name__}: {exc}"
+
+warnings.filterwarnings("ignore", message="tl.make_block_ptr is deprecated")
+triton.knobs.autotuning.adjust_block_size = False
+
+
+class _CachedPlatform:
+    """Return one cached PDL decision during benchmark iterations."""
+
+    def __init__(self, supports_pdl: bool):
+        self._supports_pdl = supports_pdl
+
+    def is_arch_support_pdl(self) -> bool:
+        return self._supports_pdl
+
+
+_flag_attn_index_module = sys.modules[minimax_m3_index_decode.__module__]
+_flag_attn_sparse_module = sys.modules[minimax_m3_sparse_attn_decode.__module__]
+_flag_attn_platform = _CachedPlatform(
+    _flag_attn_index_module.current_platform.is_arch_support_pdl()
+)
+_flag_attn_index_module.current_platform = _flag_attn_platform
+_flag_attn_sparse_module.current_platform = _flag_attn_platform
+
+if VLLM_AVAILABLE:
+    _vllm_index_module = sys.modules[vllm_index_decode.__module__]
+    _vllm_sparse_module = sys.modules[vllm_sparse_attn_decode.__module__]
+    _vllm_platform = _CachedPlatform(
+        _vllm_index_module.current_platform.is_arch_support_pdl()
+    )
+    _vllm_index_module.current_platform = _vllm_platform
+    _vllm_sparse_module.current_platform = _vllm_platform
+
+
+BLOCK = SPARSE_BLOCK_SIZE
+HEAD_DIM = 128
+FP8_DTYPE = getattr(torch, "float8_e4m3fn", None)
+DEFAULT_WARMUP = 200
+DEFAULT_REP = 300
+KV_SCALE = 0.5
+
+PREFILL_SHAPES = [
+    (1, 8192, 16, 96),
+    (2, 16384, 8, 96),
+    (4, 2048, 16, 96),
+    (4, 4096, 16, 384),
+    (8, 2048, 32, 192),
+    (2, 2048, 16, 96),
+    (4, 1024, 8, 96),
+    (8, 1024, 8, 48),
+]
+
+DECODE_SHAPES = [
+    (1, 4096, 16, 96),
+    (1, 16384, 16, 96),
+    (1, 65536, 16, 96),
+    (4, 4096, 8, 96),
+    (4, 16384, 8, 96),
+    (16, 4096, 8, 96),
+    (32, 2048, 4, 48),
+    (64, 1024, 4, 48),
+]
+
+
+@dataclass
+class MSAData:
+    q: torch.Tensor
+    idx_q: torch.Tensor
+    kv_cache: torch.Tensor
+    index_kv_cache: torch.Tensor
+    block_table: torch.Tensor
+    cu_q: torch.Tensor
+    seq_lens: torch.Tensor
+    prefix_lens: torch.Tensor
+    sm_scale: float
+    k_scale: torch.Tensor | None
+    v_scale: torch.Tensor | None
+
+
+def _require_cuda() -> None:
+    if not torch.cuda.is_available():
+        raise RuntimeError("This benchmark requires CUDA.")
+
+
+def _supports_fp8() -> bool:
+    if FP8_DTYPE is None or not torch.cuda.is_available():
+        return False
+    # NVIDIA FP8 Tensor Core support starts with Ada (8.9) and Hopper (9.0).
+    return torch.cuda.get_device_capability() >= (8, 9)
+
+
+def _encode_fp8(value: torch.Tensor, scale: float) -> torch.Tensor:
+    if FP8_DTYPE is None:
+        raise RuntimeError("This PyTorch build does not provide float8_e4m3fn.")
+    return (value / scale).to(FP8_DTYPE)
+
+
+def _random_storage(
+    shape: tuple[int, ...],
+    device: torch.device,
+    fp8: bool,
+    scale: float = 1.0,
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    # Generate in BF16 because torch.randn support for FP8 is version-dependent.
+    value = (
+        torch.randn(
+            shape,
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.5
+    )
+    return _encode_fp8(value, scale) if fp8 else value
+
+
+def make_data(
+    batch: int,
+    seq_len: int,
+    num_kv_heads: int,
+    num_heads: int,
+    device: torch.device,
+    dtype_name: str,
+    *,
+    decode: bool,
+    decode_qlen: int,
+    randomize_pages: bool = True,
+    generator: torch.Generator | None = None,
+) -> MSAData:
+    if num_heads % num_kv_heads != 0:
+        raise ValueError("num_heads must be divisible by num_kv_heads")
+    if dtype_name not in {"bf16", "fp8"}:
+        raise ValueError(f"unsupported dtype: {dtype_name}")
+    if dtype_name == "fp8" and FP8_DTYPE is None:
+        raise RuntimeError("FP8 was requested but float8_e4m3fn is unavailable.")
+
+    storage_dtype = torch.bfloat16 if dtype_name == "bf16" else FP8_DTYPE
+    blocks_per_request = (seq_len + BLOCK - 1) // BLOCK
+    total_blocks = batch * blocks_per_request
+    total_q = batch * decode_qlen if decode else batch * seq_len
+
+    q = (
+        torch.randn(
+            (total_q, num_heads, HEAD_DIM),
+            device=device,
+            dtype=torch.bfloat16,
+            generator=generator,
+        )
+        * 0.5
+    )
+    idx_q = _random_storage(
+        (total_q, num_kv_heads, HEAD_DIM),
+        device,
+        dtype_name == "fp8",
+        generator=generator,
+    )
+    k_cont = _random_storage(
+        (total_blocks * BLOCK, num_kv_heads, HEAD_DIM),
+        device,
+        dtype_name == "fp8",
+        KV_SCALE,
+        generator,
+    )
+    v_cont = _random_storage(
+        (total_blocks * BLOCK, num_kv_heads, HEAD_DIM),
+        device,
+        dtype_name == "fp8",
+        KV_SCALE,
+        generator,
+    )
+    index_k_cont = _random_storage(
+        (total_blocks * BLOCK, HEAD_DIM),
+        device,
+        dtype_name == "fp8",
+        generator=generator,
+    )
+
+    kv_cache = torch.empty(
+        (total_blocks, num_kv_heads, BLOCK, 2 * HEAD_DIM),
+        device=device,
+        dtype=storage_dtype,
+    )
+    k_paged = k_cont.reshape(total_blocks, BLOCK, num_kv_heads, HEAD_DIM).permute(
+        0, 2, 1, 3
+    )
+    v_paged = v_cont.reshape(total_blocks, BLOCK, num_kv_heads, HEAD_DIM).permute(
+        0, 2, 1, 3
+    )
+    kv_cache[..., :HEAD_DIM] = k_paged
+    kv_cache[..., HEAD_DIM:] = v_paged
+    index_kv_cache = index_k_cont.reshape(total_blocks, BLOCK, HEAD_DIM)
+
+    physical_pages = torch.randperm(total_blocks, device=device, generator=generator)
+    if not randomize_pages:
+        physical_pages = torch.arange(total_blocks, device=device)
+    block_table = physical_pages.reshape(batch, blocks_per_request).to(torch.int32)
+    if randomize_pages:
+        kv_cache = kv_cache[physical_pages.argsort()].contiguous()
+        index_kv_cache = index_kv_cache[physical_pages.argsort()].contiguous()
+
+    q_stride = decode_qlen if decode else seq_len
+    cu_q = torch.arange(
+        0,
+        (batch + 1) * q_stride,
+        q_stride,
+        device=device,
+        dtype=torch.int32,
+    )
+    seq_lens = torch.full((batch,), seq_len, device=device, dtype=torch.int32)
+    prefix_lens = torch.zeros_like(seq_lens)
+    if dtype_name == "fp8":
+        k_scale = torch.tensor([KV_SCALE], device=device, dtype=torch.float32)
+        v_scale = torch.tensor([KV_SCALE], device=device, dtype=torch.float32)
+    else:
+        k_scale = v_scale = None
+    return MSAData(
+        q,
+        idx_q,
+        kv_cache,
+        index_kv_cache,
+        block_table,
+        cu_q,
+        seq_lens,
+        prefix_lens,
+        HEAD_DIM**-0.5,
+        k_scale,
+        v_scale,
+    )
+
+
+def _call_sparse(
+    fn: Callable,
+    data: MSAData,
+    topk_idx: torch.Tensor,
+    output: torch.Tensor,
+    *,
+    decode: bool,
+    max_query_len: int,
+    num_kv_heads: int,
+    decode_qlen: int,
+) -> None:
+    common = dict(
+        q=data.q,
+        kv_cache=data.kv_cache,
+        topk_idx=topk_idx,
+        block_table=data.block_table,
+        sm_scale=data.sm_scale,
+        output=output,
+    )
+    if decode:
+        common.update(
+            seq_lens=data.seq_lens,
+            num_kv_heads=num_kv_heads,
+            decode_query_len=decode_qlen,
+        )
+    else:
+        common.update(
+            cu_seqlens_q=data.cu_q,
+            seq_lens=data.seq_lens,
+            prefix_lens=data.prefix_lens,
+            max_query_len=max_query_len,
+            num_kv_heads=num_kv_heads,
+        )
+    if data.k_scale is not None:
+        common.update(k_scale=data.k_scale, v_scale=data.v_scale)
+    fn(**common)
+
+
+def run_prefill(
+    index_score: Callable,
+    index_topk: Callable,
+    sparse_attn: Callable,
+    data: MSAData,
+    seq_len: int,
+    num_kv_heads: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    output: torch.Tensor,
+) -> None:
+    scores = index_score(
+        data.idx_q,
+        data.index_kv_cache,
+        data.block_table,
+        data.cu_q,
+        data.seq_lens,
+        data.prefix_lens,
+        seq_len,
+        seq_len,
+        num_kv_heads,
+    )
+    topk_idx = index_topk(
+        scores,
+        data.cu_q,
+        data.prefix_lens,
+        seq_len,
+        topk,
+        init_blocks,
+        local_blocks,
+    )
+    _call_sparse(
+        sparse_attn,
+        data,
+        topk_idx,
+        output,
+        decode=False,
+        max_query_len=seq_len,
+        num_kv_heads=num_kv_heads,
+        decode_qlen=1,
+    )
+
+
+def run_decode(
+    index_decode: Callable,
+    sparse_attn_decode: Callable,
+    data: MSAData,
+    seq_len: int,
+    num_kv_heads: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    decode_qlen: int,
+    output: torch.Tensor,
+) -> None:
+    topk_idx = index_decode(
+        data.idx_q,
+        data.index_kv_cache,
+        data.block_table,
+        data.seq_lens,
+        seq_len,
+        topk,
+        init_blocks,
+        local_blocks,
+        num_kv_heads,
+        decode_qlen,
+        decode_qlen,
+    )
+    _call_sparse(
+        sparse_attn_decode,
+        data,
+        topk_idx,
+        output,
+        decode=True,
+        max_query_len=1,
+        num_kv_heads=num_kv_heads,
+        decode_qlen=decode_qlen,
+    )
+
+
+def bench_fn(fn: Callable, warmup: int, rep: int) -> float:
+    for _ in range(3):
+        fn()
+    torch.cuda.synchronize()
+    return float(
+        triton_testing.do_bench(fn, warmup=warmup, rep=rep, return_mode="median")
+    )
+
+
+def _supports_fp8_scales() -> bool:
+    if not VLLM_AVAILABLE:
+        return False
+    try:
+        prefill_params = inspect.signature(vllm_sparse_attn).parameters
+        decode_params = inspect.signature(vllm_sparse_attn_decode).parameters
+    except (TypeError, ValueError):
+        return False
+    return (
+        "k_scale" in prefill_params
+        and "v_scale" in prefill_params
+        and ("k_scale" in decode_params and "v_scale" in decode_params)
+    )
+
+
+def _bench_steps(
+    data: MSAData,
+    decode: bool,
+    args: argparse.Namespace,
+    shape: tuple[int, int, int, int],
+) -> dict[str, float]:
+    batch, seq_len, num_kv_heads, _ = shape
+    output = torch.empty_like(data.q)
+    if decode:
+
+        def index_decode() -> torch.Tensor:
+            return minimax_m3_index_decode(
+                data.idx_q,
+                data.index_kv_cache,
+                data.block_table,
+                data.seq_lens,
+                seq_len,
+                args.topk,
+                args.init_blocks,
+                args.local_blocks,
+                num_kv_heads,
+                args.decode_qlen,
+                args.decode_qlen,
+            )
+
+        topk_idx = index_decode()
+
+        def attention() -> None:
+            _call_sparse(
+                minimax_m3_sparse_attn_decode,
+                data,
+                topk_idx,
+                output,
+                decode=True,
+                max_query_len=1,
+                num_kv_heads=num_kv_heads,
+                decode_qlen=args.decode_qlen,
+            )
+
+        attention()
+        torch.cuda.synchronize()
+        return {
+            "index_decode": bench_fn(index_decode, args.warmup, args.rep),
+            "attention_decode": bench_fn(attention, args.warmup, args.rep),
+        }
+
+    scores: torch.Tensor | None = None
+    topk_idx: torch.Tensor | None = None
+
+    def index_score() -> None:
+        nonlocal scores
+        scores = minimax_m3_index_score(
+            data.idx_q,
+            data.index_kv_cache,
+            data.block_table,
+            data.cu_q,
+            data.seq_lens,
+            data.prefix_lens,
+            seq_len,
+            seq_len,
+            num_kv_heads,
+        )
+
+    def index_topk() -> None:
+        nonlocal topk_idx
+        assert scores is not None
+        topk_idx = minimax_m3_index_topk(
+            scores,
+            data.cu_q,
+            data.prefix_lens,
+            seq_len,
+            args.topk,
+            args.init_blocks,
+            args.local_blocks,
+        )
+
+    def attention() -> None:
+        assert topk_idx is not None
+        _call_sparse(
+            minimax_m3_sparse_attn,
+            data,
+            topk_idx,
+            output,
+            decode=False,
+            max_query_len=seq_len,
+            num_kv_heads=num_kv_heads,
+            decode_qlen=1,
+        )
+
+    index_score()
+    index_topk()
+    attention()
+    torch.cuda.synchronize()
+    return {
+        "index_score": bench_fn(index_score, args.warmup, args.rep),
+        "index_topk": bench_fn(index_topk, args.warmup, args.rep),
+        "attention": bench_fn(attention, args.warmup, args.rep),
+    }
+
+
+def _parse_shape(value: str) -> tuple[int, int, int, int]:
+    try:
+        shape = tuple(int(item) for item in value.split(","))
+    except ValueError as exc:
+        raise ValueError(
+            "--shape must contain four comma-separated integers: "
+            "batch,seq_len,num_kv_heads,num_heads"
+        ) from exc
+    if len(shape) != 4 or any(item <= 0 for item in shape):
+        raise ValueError(
+            "--shape must contain four positive integers: "
+            "batch,seq_len,num_kv_heads,num_heads"
+        )
+    return shape
+
+
+def _get_shapes(args: argparse.Namespace) -> list[tuple[int, int, int, int]]:
+    if args.shape is not None and not args.all_shapes:
+        return [_parse_shape(args.shape)]
+    return DECODE_SHAPES if args.decode else PREFILL_SHAPES
+
+
+def _format_columns(columns: list[tuple[str, int]]) -> str:
+    return "  ".join(f"{value:>{width}s}" for value, width in columns)
+
+
+def _run_dtype(args: argparse.Namespace, dtype_name: str) -> None:
+    run_vllm = VLLM_AVAILABLE and not args.no_vllm
+    if dtype_name == "fp8" and run_vllm and not _supports_fp8_scales():
+        print("[baseline] vLLM FP8 skipped: k_scale/v_scale are unavailable")
+        run_vllm = False
+
+    mode = f"decode qlen={args.decode_qlen}" if args.decode else "prefill"
+    page_mode = "identity" if args.identity_pages else "random"
+    print(f"\nMiniMax M3 paged sparse attention ({mode})")
+    print(
+        f"dtype={dtype_name}, topk={args.topk}, "
+        f"init/local={args.init_blocks}/{args.local_blocks}, "
+        f"pages={page_mode}, seed={args.seed}, "
+        f"warmup={args.warmup}ms, rep={args.rep}ms"
+    )
+    print("Timing: eager execution with CUDA events")
+    if run_vllm:
+        print("Provider order: alternates by shape")
+    else:
+        print("vLLM baseline: unavailable; FlagAttention only")
+
+    headers = [("Shape [B,S,KVH,H]", 22), ("FlagAttn(ms)", 13)]
+    if run_vllm:
+        headers.extend([("vLLM(ms)", 10), ("vLLM/ours", 10)])
+    if args.per_step:
+        if args.decode:
+            headers.extend([("IdxDec(ms)", 11), ("AttnDec(ms)", 11)])
+        else:
+            headers.extend([("Score(ms)", 10), ("TopK(ms)", 10), ("Attn(ms)", 10)])
+    separator = "-" * len(_format_columns(headers))
+    print(separator)
+    print(_format_columns(headers))
+    print(separator)
+
+    device = torch.device("cuda")
+    for shape_index, shape in enumerate(_get_shapes(args)):
+        batch, seq_len, num_kv_heads, num_heads = shape
+        if num_heads % num_kv_heads != 0:
+            raise ValueError(
+                f"Invalid shape {shape}: num_heads must be divisible by " "num_kv_heads"
+            )
+        if args.decode and args.decode_qlen > seq_len:
+            raise ValueError(
+                f"Invalid shape {shape}: decode_qlen={args.decode_qlen} "
+                "cannot exceed seq_len"
+            )
+
+        generator = torch.Generator(device=device)
+        generator.manual_seed(args.seed + shape_index + (100_000 if args.decode else 0))
+        data = make_data(
+            batch,
+            seq_len,
+            num_kv_heads,
+            num_heads,
+            device,
+            dtype_name,
+            decode=args.decode,
+            decode_qlen=args.decode_qlen,
+            randomize_pages=not args.identity_pages,
+            generator=generator,
+        )
+        flag_attn_output = torch.empty_like(data.q)
+        vllm_output = torch.empty_like(data.q) if run_vllm else None
+
+        def flag_attn_run() -> None:
+            if args.decode:
+                run_decode(
+                    minimax_m3_index_decode,
+                    minimax_m3_sparse_attn_decode,
+                    data,
+                    seq_len,
+                    num_kv_heads,
+                    args.topk,
+                    args.init_blocks,
+                    args.local_blocks,
+                    args.decode_qlen,
+                    flag_attn_output,
+                )
+            else:
+                run_prefill(
+                    minimax_m3_index_score,
+                    minimax_m3_index_topk,
+                    minimax_m3_sparse_attn,
+                    data,
+                    seq_len,
+                    num_kv_heads,
+                    args.topk,
+                    args.init_blocks,
+                    args.local_blocks,
+                    flag_attn_output,
+                )
+
+        def vllm_run() -> None:
+            assert vllm_output is not None
+            if args.decode:
+                run_decode(
+                    vllm_index_decode,
+                    vllm_sparse_attn_decode,
+                    data,
+                    seq_len,
+                    num_kv_heads,
+                    args.topk,
+                    args.init_blocks,
+                    args.local_blocks,
+                    args.decode_qlen,
+                    vllm_output,
+                )
+            else:
+                run_prefill(
+                    vllm_index_score,
+                    vllm_index_topk,
+                    vllm_sparse_attn,
+                    data,
+                    seq_len,
+                    num_kv_heads,
+                    args.topk,
+                    args.init_blocks,
+                    args.local_blocks,
+                    vllm_output,
+                )
+
+        if run_vllm:
+            providers = (
+                (("flag_attn", flag_attn_run), ("vllm", vllm_run))
+                if shape_index % 2 == 0
+                else (("vllm", vllm_run), ("flag_attn", flag_attn_run))
+            )
+            timings = {
+                name: bench_fn(fn, args.warmup, args.rep) for name, fn in providers
+            }
+            flag_attn_ms = timings["flag_attn"]
+            vllm_ms = timings["vllm"]
+        else:
+            flag_attn_ms = bench_fn(flag_attn_run, args.warmup, args.rep)
+
+        steps = _bench_steps(data, args.decode, args, shape) if args.per_step else {}
+        row = [
+            (f"{batch}x{seq_len}x{num_kv_heads}x{num_heads}", 22),
+            (f"{flag_attn_ms:.4f}", 13),
+        ]
+        if run_vllm:
+            row.extend(
+                [
+                    (f"{vllm_ms:.4f}", 10),
+                    (f"{vllm_ms / flag_attn_ms:.2f}x", 10),
+                ]
+            )
+        if args.per_step:
+            if args.decode:
+                row.extend(
+                    [
+                        (f"{steps['index_decode']:.4f}", 11),
+                        (f"{steps['attention_decode']:.4f}", 11),
+                    ]
+                )
+            else:
+                row.extend(
+                    [
+                        (f"{steps['index_score']:.4f}", 10),
+                        (f"{steps['index_topk']:.4f}", 10),
+                        (f"{steps['attention']:.4f}", 10),
+                    ]
+                )
+        print(_format_columns(row))
+        sys.stdout.flush()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dtype", choices=("bf16", "fp8", "both"), default="bf16")
+    parser.add_argument("--shape", default=None)
+    parser.add_argument("--topk", type=int, default=32)
+    parser.add_argument("--init-blocks", type=int, default=1)
+    parser.add_argument("--local-blocks", type=int, default=2)
+    parser.add_argument("--all-shapes", action="store_true")
+    parser.add_argument("--per-step", action="store_true")
+    parser.add_argument("--identity-pages", action="store_true")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--prefill-only", action="store_true")
+    mode.add_argument(
+        "--decode-only", "--decode", dest="decode_only", action="store_true"
+    )
+    parser.add_argument("--decode-qlen", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=DEFAULT_WARMUP)
+    parser.add_argument("--rep", type=int, default=DEFAULT_REP)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--no-vllm", action="store_true")
+    return parser.parse_args(argv)
+
+
+def run_benchmark(args: argparse.Namespace) -> None:
+    _require_cuda()
+    if args.decode_qlen < 1:
+        raise ValueError("--decode-qlen must be positive")
+    if args.warmup < 0 or args.rep <= 0:
+        raise ValueError("--warmup must be non-negative and --rep must be positive")
+    capability = torch.cuda.get_device_capability()
+    print(
+        f"[device] {torch.cuda.get_device_name()} "
+        f"capability={capability[0]}.{capability[1]}"
+    )
+    if args.prefill_only:
+        modes = (False,)
+    elif args.decode_only:
+        modes = (True,)
+    else:
+        modes = (False, True)
+    if args.dtype in {"fp8", "both"} and not _supports_fp8():
+        print("[FP8] skipped: this GPU or PyTorch build does not support FP8")
+    if args.dtype == "fp8" and not _supports_fp8():
+        return
+    dtypes = (
+        ("bf16", "fp8")
+        if args.dtype == "both" and _supports_fp8()
+        else ("bf16",) if args.dtype == "both" else (args.dtype,)
+    )
+
+    if args.no_vllm:
+        print("[baseline] vLLM skipped (--no-vllm)")
+    elif VLLM_AVAILABLE:
+        print("[baseline] vLLM enabled")
+    else:
+        print(f"[baseline] vLLM skipped ({VLLM_IMPORT_ERROR})")
+
+    for mode_index, decode in enumerate(modes):
+        args.decode = decode
+        if mode_index:
+            print()
+        for dtype_name in dtypes:
+            _run_dtype(args, dtype_name)
+
+
+def test_msa_benchmark() -> None:
+    """Run the MSA benchmark through pytest with default timing options."""
+    args = parse_args([])
+    args.per_step = True
+    run_benchmark(args)
+
+
+def main() -> None:
+    run_benchmark(parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/minimax_sparse_attention_benchmark.py
+++ b/benchmark/minimax_sparse_attention_benchmark.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2026 FlagOS Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,6 +102,11 @@ FP8_DTYPE = getattr(torch, "float8_e4m3fn", None)
 DEFAULT_WARMUP = 200
 DEFAULT_REP = 300
 KV_SCALE = 0.5
+SEED = 0
+TOPK = 16
+INIT_BLOCKS = 1
+LOCAL_BLOCKS = 2
+DECODE_QLEN = 1
 
 PREFILL_SHAPES = [
     (1, 8192, 16, 96),
@@ -123,26 +127,6 @@ DECODE_SHAPES = [
     (32, 2048, 4, 48),
     (64, 1024, 4, 48),
 ]
-
-
-@dataclass
-class MSABenchmarkArgs:
-    dtype: str = "both"
-    shape: str | None = None
-    topk: int = 16
-    init_blocks: int = 1
-    local_blocks: int = 2
-    all_shapes: bool = False
-    per_step: bool = True
-    identity_pages: bool = False
-    prefill_only: bool = False
-    decode_only: bool = False
-    decode_qlen: int = 1
-    warmup: int = DEFAULT_WARMUP
-    rep: int = DEFAULT_REP
-    seed: int = 0
-    no_vllm: bool = False
-    decode: bool = False
 
 
 @dataclass
@@ -459,349 +443,129 @@ def _supports_fp8_scales() -> bool:
     )
 
 
-def _bench_steps(
-    data: MSAData,
-    decode: bool,
-    args: MSABenchmarkArgs,
-    shape: tuple[int, int, int, int],
-) -> dict[str, float]:
-    batch, seq_len, num_kv_heads, _ = shape
+def _select_impl(
+    provider: str,
+) -> tuple[Callable, Callable, Callable, Callable, Callable]:
+    if provider == "flag_attn":
+        return (
+            minimax_m3_index_decode,
+            minimax_m3_index_score,
+            minimax_m3_index_topk,
+            minimax_m3_sparse_attn,
+            minimax_m3_sparse_attn_decode,
+        )
+    if provider == "vllm":
+        return (
+            vllm_index_decode,
+            vllm_index_score,
+            vllm_index_topk,
+            vllm_sparse_attn,
+            vllm_sparse_attn_decode,
+        )
+    raise ValueError(f"unknown provider: {provider}")
+
+
+def _provider_vals(dtype_name: str) -> list[str]:
+    vals = ["flag_attn"]
+    if VLLM_AVAILABLE:
+        # vLLM cannot run FP8 without k_scale/v_scale support.
+        if dtype_name == "fp8" and not _supports_fp8_scales():
+            pass
+        else:
+            vals.append("vllm")
+    return vals
+
+
+_DTYPES = ["bf16"] + (["fp8"] if _supports_fp8() else [])
+
+configs = [
+    triton.testing.Benchmark(
+        x_names=["shape"],
+        x_vals=SHAPES,
+        line_arg="provider",
+        line_vals=_provider_vals(dtype_name),
+        line_names=_provider_vals(dtype_name),
+        styles=[("red", "-"), ("blue", "-")],
+        ylabel="ms",
+        plot_name=f"minimax_m3_sparse_attention-{mode}-{dtype_name}",
+        args={"mode": mode, "dtype": dtype_name},
+    )
+    for mode, SHAPES in [("prefill", PREFILL_SHAPES), ("decode", DECODE_SHAPES)]
+    for dtype_name in _DTYPES
+]
+
+
+@triton.testing.perf_report(configs)
+def bench_minimax_sparse_attention(
+    shape, mode, provider, dtype="bf16", device="cuda"
+):
+    _require_cuda()
+    batch, seq_len, num_kv_heads, num_heads = shape
+    decode = mode == "decode"
+
+    if num_heads % num_kv_heads != 0:
+        raise ValueError(
+            f"Invalid shape {shape}: num_heads must be divisible by num_kv_heads"
+        )
+    if decode and DECODE_QLEN > seq_len:
+        raise ValueError(
+            f"Invalid shape {shape}: decode_qlen={DECODE_QLEN} cannot exceed seq_len"
+        )
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(SEED + (100_000 if decode else 0))
+    data = make_data(
+        batch,
+        seq_len,
+        num_kv_heads,
+        num_heads,
+        torch.device(device),
+        dtype,
+        decode=decode,
+        decode_qlen=DECODE_QLEN,
+        randomize_pages=dtype != "fp8",
+        generator=generator,
+    )
     output = torch.empty_like(data.q)
+
+    index_decode, index_score, index_topk, sparse_attn, sparse_attn_decode = (
+        _select_impl(provider)
+    )
+
     if decode:
 
-        def index_decode() -> torch.Tensor:
-            return minimax_m3_index_decode(
-                data.idx_q,
-                data.index_kv_cache,
-                data.block_table,
-                data.seq_lens,
-                seq_len,
-                args.topk,
-                args.init_blocks,
-                args.local_blocks,
-                num_kv_heads,
-                args.decode_qlen,
-                args.decode_qlen,
-            )
-
-        topk_idx = index_decode()
-
-        def attention() -> None:
-            _call_sparse(
-                minimax_m3_sparse_attn_decode,
+        def run() -> None:
+            run_decode(
+                index_decode,
+                sparse_attn_decode,
                 data,
-                topk_idx,
+                seq_len,
+                num_kv_heads,
+                TOPK,
+                INIT_BLOCKS,
+                LOCAL_BLOCKS,
+                DECODE_QLEN,
                 output,
-                decode=True,
-                max_query_len=1,
-                num_kv_heads=num_kv_heads,
-                decode_qlen=args.decode_qlen,
             )
 
-        attention()
-        torch.cuda.synchronize()
-        return {
-            "index_decode": bench_fn(index_decode, args.warmup, args.rep),
-            "attention_decode": bench_fn(attention, args.warmup, args.rep),
-        }
-
-    scores: torch.Tensor | None = None
-    topk_idx: torch.Tensor | None = None
-
-    def index_score() -> None:
-        nonlocal scores
-        scores = minimax_m3_index_score(
-            data.idx_q,
-            data.index_kv_cache,
-            data.block_table,
-            data.cu_q,
-            data.seq_lens,
-            data.prefix_lens,
-            seq_len,
-            seq_len,
-            num_kv_heads,
-        )
-
-    def index_topk() -> None:
-        nonlocal topk_idx
-        assert scores is not None
-        topk_idx = minimax_m3_index_topk(
-            scores,
-            data.cu_q,
-            data.prefix_lens,
-            seq_len,
-            args.topk,
-            args.init_blocks,
-            args.local_blocks,
-        )
-
-    def attention() -> None:
-        assert topk_idx is not None
-        _call_sparse(
-            minimax_m3_sparse_attn,
-            data,
-            topk_idx,
-            output,
-            decode=False,
-            max_query_len=seq_len,
-            num_kv_heads=num_kv_heads,
-            decode_qlen=1,
-        )
-
-    index_score()
-    index_topk()
-    attention()
-    torch.cuda.synchronize()
-    return {
-        "index_score": bench_fn(index_score, args.warmup, args.rep),
-        "index_topk": bench_fn(index_topk, args.warmup, args.rep),
-        "attention": bench_fn(attention, args.warmup, args.rep),
-    }
-
-
-def _parse_shape(value: str) -> tuple[int, int, int, int]:
-    try:
-        shape = tuple(int(item) for item in value.split(","))
-    except ValueError as exc:
-        raise ValueError(
-            "--shape must contain four comma-separated integers: "
-            "batch,seq_len,num_kv_heads,num_heads"
-        ) from exc
-    if len(shape) != 4 or any(item <= 0 for item in shape):
-        raise ValueError(
-            "--shape must contain four positive integers: "
-            "batch,seq_len,num_kv_heads,num_heads"
-        )
-    return shape
-
-
-def _get_shapes(args: MSABenchmarkArgs) -> list[tuple[int, int, int, int]]:
-    if args.shape is not None and not args.all_shapes:
-        return [_parse_shape(args.shape)]
-    return DECODE_SHAPES if args.decode else PREFILL_SHAPES
-
-
-def _format_columns(columns: list[tuple[str, int]]) -> str:
-    return "  ".join(f"{value:>{width}s}" for value, width in columns)
-
-
-def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
-    run_vllm = VLLM_AVAILABLE and not args.no_vllm
-    if dtype_name == "fp8" and run_vllm and not _supports_fp8_scales():
-        print("[baseline] vLLM FP8 skipped: k_scale/v_scale are unavailable")
-        run_vllm = False
-
-    mode = f"decode qlen={args.decode_qlen}" if args.decode else "prefill"
-    use_identity_pages = args.identity_pages or dtype_name == "fp8"
-    page_mode = "identity" if use_identity_pages else "random"
-    print(f"\nMiniMax M3 paged sparse attention ({mode})")
-    print(
-        f"dtype={dtype_name}, topk={args.topk}, "
-        f"init/local={args.init_blocks}/{args.local_blocks}, "
-        f"pages={page_mode}, seed={args.seed}, "
-        f"warmup={args.warmup}ms, rep={args.rep}ms"
-    )
-    print("Timing: eager execution with CUDA events")
-    if run_vllm:
-        print("Provider order: alternates by shape")
     else:
-        print("vLLM baseline: unavailable; FlagAttn only")
 
-    headers = [("Shape [B,S,KVH,H]", 22), ("FlagAttn(ms)", 13)]
-    if run_vllm:
-        headers.extend([("vLLM(ms)", 10), ("vLLM/ours", 10)])
-    if args.per_step:
-        if args.decode:
-            headers.extend([("IdxDec(ms)", 11), ("AttnDec(ms)", 11)])
-        else:
-            headers.extend([("Score(ms)", 10), ("TopK(ms)", 10), ("Attn(ms)", 10)])
-    separator = "-" * len(_format_columns(headers))
-    print(separator)
-    print(_format_columns(headers))
-    print(separator)
-
-    device = torch.device("cuda")
-    for shape_index, shape in enumerate(_get_shapes(args)):
-        batch, seq_len, num_kv_heads, num_heads = shape
-        if num_heads % num_kv_heads != 0:
-            raise ValueError(
-                f"Invalid shape {shape}: num_heads must be divisible by " "num_kv_heads"
-            )
-        if args.decode and args.decode_qlen > seq_len:
-            raise ValueError(
-                f"Invalid shape {shape}: decode_qlen={args.decode_qlen} "
-                "cannot exceed seq_len"
+        def run() -> None:
+            run_prefill(
+                index_score,
+                index_topk,
+                sparse_attn,
+                data,
+                seq_len,
+                num_kv_heads,
+                TOPK,
+                INIT_BLOCKS,
+                LOCAL_BLOCKS,
+                output,
             )
 
-        generator = torch.Generator(device=device)
-        generator.manual_seed(args.seed + shape_index + (100_000 if args.decode else 0))
-        data = make_data(
-            batch,
-            seq_len,
-            num_kv_heads,
-            num_heads,
-            device,
-            dtype_name,
-            decode=args.decode,
-            decode_qlen=args.decode_qlen,
-            randomize_pages=not use_identity_pages,
-            generator=generator,
-        )
-        flag_attn_output = torch.empty_like(data.q)
-        vllm_output = torch.empty_like(data.q) if run_vllm else None
-
-        def flag_attn_run() -> None:
-            if args.decode:
-                run_decode(
-                    minimax_m3_index_decode,
-                    minimax_m3_sparse_attn_decode,
-                    data,
-                    seq_len,
-                    num_kv_heads,
-                    args.topk,
-                    args.init_blocks,
-                    args.local_blocks,
-                    args.decode_qlen,
-                    flag_attn_output,
-                )
-            else:
-                run_prefill(
-                    minimax_m3_index_score,
-                    minimax_m3_index_topk,
-                    minimax_m3_sparse_attn,
-                    data,
-                    seq_len,
-                    num_kv_heads,
-                    args.topk,
-                    args.init_blocks,
-                    args.local_blocks,
-                    flag_attn_output,
-                )
-
-        def vllm_run() -> None:
-            assert vllm_output is not None
-            if args.decode:
-                run_decode(
-                    vllm_index_decode,
-                    vllm_sparse_attn_decode,
-                    data,
-                    seq_len,
-                    num_kv_heads,
-                    args.topk,
-                    args.init_blocks,
-                    args.local_blocks,
-                    args.decode_qlen,
-                    vllm_output,
-                )
-            else:
-                run_prefill(
-                    vllm_index_score,
-                    vllm_index_topk,
-                    vllm_sparse_attn,
-                    data,
-                    seq_len,
-                    num_kv_heads,
-                    args.topk,
-                    args.init_blocks,
-                    args.local_blocks,
-                    vllm_output,
-                )
-
-        if run_vllm:
-            providers = (
-                (("flag_attn", flag_attn_run), ("vllm", vllm_run))
-                if shape_index % 2 == 0
-                else (("vllm", vllm_run), ("flag_attn", flag_attn_run))
-            )
-            timings = {
-                name: bench_fn(fn, args.warmup, args.rep) for name, fn in providers
-            }
-            flag_attn_ms = timings["flag_attn"]
-            vllm_ms = timings["vllm"]
-        else:
-            flag_attn_ms = bench_fn(flag_attn_run, args.warmup, args.rep)
-
-        steps = _bench_steps(data, args.decode, args, shape) if args.per_step else {}
-        row = [
-            (f"{batch}x{seq_len}x{num_kv_heads}x{num_heads}", 22),
-            (f"{flag_attn_ms:.4f}", 13),
-        ]
-        if run_vllm:
-            row.extend(
-                [
-                    (f"{vllm_ms:.4f}", 10),
-                    (f"{vllm_ms / flag_attn_ms:.2f}x", 10),
-                ]
-            )
-        if args.per_step:
-            if args.decode:
-                row.extend(
-                    [
-                        (f"{steps['index_decode']:.4f}", 11),
-                        (f"{steps['attention_decode']:.4f}", 11),
-                    ]
-                )
-            else:
-                row.extend(
-                    [
-                        (f"{steps['index_score']:.4f}", 10),
-                        (f"{steps['index_topk']:.4f}", 10),
-                        (f"{steps['attention']:.4f}", 10),
-                    ]
-                )
-        print(_format_columns(row))
-        sys.stdout.flush()
+    return bench_fn(run, DEFAULT_WARMUP, DEFAULT_REP)
 
 
-def run_benchmark(args: MSABenchmarkArgs) -> None:
-    _require_cuda()
-    if args.topk < 1:
-        raise ValueError("--topk must be positive")
-    if args.decode_qlen < 1:
-        raise ValueError("--decode-qlen must be positive")
-    if args.warmup < 0 or args.rep <= 0:
-        raise ValueError("--warmup must be non-negative and --rep must be positive")
-    capability = torch.cuda.get_device_capability()
-    print(
-        f"[device] {torch.cuda.get_device_name()} "
-        f"capability={capability[0]}.{capability[1]}"
-    )
-    if args.prefill_only:
-        modes = (False,)
-    elif args.decode_only:
-        modes = (True,)
-    else:
-        modes = (False, True)
-    if args.dtype in {"fp8", "both"} and not _supports_fp8():
-        print("[FP8] skipped: this GPU or PyTorch build does not support FP8")
-    if args.dtype == "fp8" and not _supports_fp8():
-        return
-    dtypes = (
-        ("bf16", "fp8")
-        if args.dtype == "both" and _supports_fp8()
-        else ("bf16",) if args.dtype == "both" else (args.dtype,)
-    )
-
-    if args.no_vllm:
-        print("[baseline] vLLM skipped (--no-vllm)")
-    elif VLLM_AVAILABLE:
-        print("[baseline] vLLM enabled")
-    else:
-        print(f"[baseline] vLLM skipped ({VLLM_IMPORT_ERROR})")
-
-    for mode_index, decode in enumerate(modes):
-        args.decode = decode
-        if mode_index:
-            print()
-        for dtype_name in dtypes:
-            _run_dtype(args, dtype_name)
-
-
-def test_msa_benchmark(request) -> None:
-    """Run the MSA benchmark through pytest using benchmark CLI timing options."""
-    args = MSABenchmarkArgs(
-        topk=int(request.config.getoption("--topk", default=16)),
-        warmup=int(request.config.getoption("--warmup", default=DEFAULT_WARMUP)),
-        rep=int(request.config.getoption("--iter", default=DEFAULT_REP)),
-    )
-    run_benchmark(args)
+# only works on post-Ampere GPUs right now
+bench_minimax_sparse_attention.run(print_data=True)

--- a/benchmark/minimax_sparse_attention_benchmark.py
+++ b/benchmark/minimax_sparse_attention_benchmark.py
@@ -1,6 +1,21 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """CUDA benchmark for the MiniMax M3 paged MSA kernels.
 
-The benchmark compares the FlagGems and vLLM implementations on the same
+The benchmark compares the FlagAttention and vLLM implementations on the same
 inputs.  ``fp8`` means FP8 index queries/index keys and FP8 main KV cache,
 with scalar K/V dequantization scales passed to both implementations.
 """
@@ -64,13 +79,13 @@ class _CachedPlatform:
         return self._supports_pdl
 
 
-_flaggems_index_module = sys.modules[minimax_m3_index_decode.__module__]
-_flaggems_sparse_module = sys.modules[minimax_m3_sparse_attn_decode.__module__]
-_flaggems_platform = _CachedPlatform(
-    _flaggems_index_module.current_platform.is_arch_support_pdl()
+_flag_attn_index_module = sys.modules[minimax_m3_index_decode.__module__]
+_flag_attn_sparse_module = sys.modules[minimax_m3_sparse_attn_decode.__module__]
+_flag_attn_platform = _CachedPlatform(
+    _flag_attn_index_module.current_platform.is_arch_support_pdl()
 )
-_flaggems_index_module.current_platform = _flaggems_platform
-_flaggems_sparse_module.current_platform = _flaggems_platform
+_flag_attn_index_module.current_platform = _flag_attn_platform
+_flag_attn_sparse_module.current_platform = _flag_attn_platform
 
 if VLLM_AVAILABLE:
     _vllm_index_module = sys.modules[vllm_index_decode.__module__]
@@ -590,9 +605,9 @@ def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
     if run_vllm:
         print("Provider order: alternates by shape")
     else:
-        print("vLLM baseline: unavailable; FlagGems only")
+        print("vLLM baseline: unavailable; FlagAttn only")
 
-    headers = [("Shape [B,S,KVH,H]", 22), ("FlagGems(ms)", 13)]
+    headers = [("Shape [B,S,KVH,H]", 22), ("FlagAttn(ms)", 13)]
     if run_vllm:
         headers.extend([("vLLM(ms)", 10), ("vLLM/ours", 10)])
     if args.per_step:
@@ -632,10 +647,10 @@ def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
             randomize_pages=not use_identity_pages,
             generator=generator,
         )
-        flaggems_output = torch.empty_like(data.q)
+        flag_attn_output = torch.empty_like(data.q)
         vllm_output = torch.empty_like(data.q) if run_vllm else None
 
-        def flaggems_run() -> None:
+        def flag_attn_run() -> None:
             if args.decode:
                 run_decode(
                     minimax_m3_index_decode,
@@ -647,7 +662,7 @@ def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
                     args.init_blocks,
                     args.local_blocks,
                     args.decode_qlen,
-                    flaggems_output,
+                    flag_attn_output,
                 )
             else:
                 run_prefill(
@@ -660,7 +675,7 @@ def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
                     args.topk,
                     args.init_blocks,
                     args.local_blocks,
-                    flaggems_output,
+                    flag_attn_output,
                 )
 
         def vllm_run() -> None:
@@ -694,28 +709,28 @@ def _run_dtype(args: MSABenchmarkArgs, dtype_name: str) -> None:
 
         if run_vllm:
             providers = (
-                (("flaggems", flaggems_run), ("vllm", vllm_run))
+                (("flag_attn", flag_attn_run), ("vllm", vllm_run))
                 if shape_index % 2 == 0
-                else (("vllm", vllm_run), ("flaggems", flaggems_run))
+                else (("vllm", vllm_run), ("flag_attn", flag_attn_run))
             )
             timings = {
                 name: bench_fn(fn, args.warmup, args.rep) for name, fn in providers
             }
-            flaggems_ms = timings["flaggems"]
+            flag_attn_ms = timings["flag_attn"]
             vllm_ms = timings["vllm"]
         else:
-            flaggems_ms = bench_fn(flaggems_run, args.warmup, args.rep)
+            flag_attn_ms = bench_fn(flag_attn_run, args.warmup, args.rep)
 
         steps = _bench_steps(data, args.decode, args, shape) if args.per_step else {}
         row = [
             (f"{batch}x{seq_len}x{num_kv_heads}x{num_heads}", 22),
-            (f"{flaggems_ms:.4f}", 13),
+            (f"{flag_attn_ms:.4f}", 13),
         ]
         if run_vllm:
             row.extend(
                 [
                     (f"{vllm_ms:.4f}", 10),
-                    (f"{vllm_ms / flaggems_ms:.2f}x", 10),
+                    (f"{vllm_ms / flag_attn_ms:.2f}x", 10),
                 ]
             )
         if args.per_step:

--- a/src/flag_attn/__init__.py
+++ b/src/flag_attn/__init__.py
@@ -25,6 +25,7 @@ from flag_attn.flash import attention as flash_attention # noqa: F401
 from flag_attn.split_kv import attention as flash_attention_split_kv # noqa: F401
 from flag_attn.paged import attention as paged_attention # noqa: F401
 from flag_attn.gated_delta_rule import chunk_gated_delta_rule # noqa: F401
+from flag_attn.gated_linear_attention import chunk_gla as chunk_gla
 from flag_attn.minimax_sparse_attention import (
     minimax_m3_index_decode as minimax_m3_index_decode,
     minimax_m3_index_decode_score as minimax_m3_index_decode_score,

--- a/src/flag_attn/__init__.py
+++ b/src/flag_attn/__init__.py
@@ -25,5 +25,13 @@ from flag_attn.flash import attention as flash_attention # noqa: F401
 from flag_attn.split_kv import attention as flash_attention_split_kv # noqa: F401
 from flag_attn.paged import attention as paged_attention # noqa: F401
 from flag_attn.gated_delta_rule import chunk_gated_delta_rule # noqa: F401
+from flag_attn.minimax_sparse_attention import (
+    minimax_m3_index_decode as minimax_m3_index_decode,
+    minimax_m3_index_decode_score as minimax_m3_index_decode_score,
+    minimax_m3_index_score as minimax_m3_index_score,
+    minimax_m3_index_topk as minimax_m3_index_topk,
+    minimax_m3_sparse_attn as minimax_m3_sparse_attn,
+    minimax_m3_sparse_attn_decode as minimax_m3_sparse_attn_decode,
+)
 
 from flag_attn import testing # noqa: F401

--- a/src/flag_attn/gated_linear_attention/__init__.py
+++ b/src/flag_attn/gated_linear_attention/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Chunked gated linear attention implemented with Triton kernels."""
+
+from .chunk_gla import chunk_gla
+
+__all__ = ["chunk_gla"]

--- a/src/flag_attn/gated_linear_attention/chunk_gla.py
+++ b/src/flag_attn/gated_linear_attention/chunk_gla.py
@@ -1,0 +1,1994 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+try:
+    HAS_TLE = False
+    import triton.experimental.tle.language as tle  # noqa: F401
+
+    HAS_TLE = True
+except ImportError:
+    tle = None
+    HAS_TLE = False
+
+from .chunk_h import chunk_bwd_dh, chunk_fwd_h
+from .cumsum import chunk_local_cumsum
+from .index import prepare_chunk_indices
+from .utils import check_shared_mem, input_guard
+
+RCP_LN2 = 1.4426950216
+
+BK_LIST = [32, 64] if check_shared_mem() else [16, 32]
+BV_LIST = [64, 128] if check_shared_mem("ampere") else [16, 32]
+
+
+@triton.jit
+def exp2(x):
+    return tl.math.exp2(x.to(tl.float32))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BK": BK},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in [32, 64]
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BC"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_A_kernel_intra_sub_inter(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_i, i_j = i_c // NC, i_c % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+    if i_i <= i_j:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_q = tl.make_block_ptr(
+            q + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT + i_i * BC, i_k * BK),
+            (BC, BK),
+            (1, 0),
+        )
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT + i_i * BC, i_k * BK),
+            (BC, BK),
+            (1, 0),
+        )
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT + i_j * BC),
+            (BK, BC),
+            (0, 1),
+        )
+        p_gk = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT + i_j * BC),
+            (BK, BC),
+            (0, 1),
+        )
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        # [BC, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_g = tl.load(p_g, boundary_check=(0, 1))
+        b_qg = b_q * exp2(b_g - b_gn[None, :]) * scale
+        # [BK, BC]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_kg = b_k * exp2(b_gn[:, None] - b_gk)
+        # [BC, BC] using tf32 to improve precision here.
+        b_A += tl.dot(b_qg, b_kg)
+
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + i_i * BC, i_j * BC),
+        (BC, BC),
+        (1, 0),
+    )
+    tl.store(p_A, b_A.to(A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3]
+    ],
+    key=["BK", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_A_kernel_intra_sub_intra(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_i, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    m_s = tl.arange(0, BC)[:, None] >= tl.arange(0, BC)[None, :]
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    A += (bos * H + i_h) * BT
+
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0)
+    )
+    p_g = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_i * BC, 0), (BC, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0)
+    )
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, 0), (BC, BK), (1, 0)
+    )
+    p_A = tl.make_block_ptr(
+        A, (T, BT), (H * BT, 1), (i_t * BT + i_i * BC, i_j * BC), (BC, BC), (1, 0)
+    )
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+
+    # Use tile dot to avoid a large [BC, BC, BK] temporary that can hurt occupancy.
+    g_max = tl.max(b_g, axis=0)
+    g_min = tl.min(b_g, axis=0)
+    g_mid = 0.5 * (g_max + g_min)
+    b_qg = b_q * exp2(b_g - g_mid[None, :])
+    b_kg = b_k * exp2(-b_gk + g_mid[None, :])
+    b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
+    b_A = tl.where(m_s, b_A, 0.0)
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    key=["BC", "BK"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_split(
+    q,
+    k,
+    g,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_k, i_tc, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_t, i_i = i_tc // NC, i_tc % NC
+    i_j = i_i
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    m_s = tl.arange(0, BC)[:, None] >= tl.arange(0, BC)[None, :]
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    g += (bos * H + i_h) * K
+    A += ((i_k * all + bos) * H + i_h) * BC
+
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_g = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_i * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT + i_j * BC, i_k * BK), (BC, BK), (1, 0)
+    )
+    p_A = tl.make_block_ptr(
+        A, (T, BC), (H * BC, 1), (i_t * BT + i_i * BC, 0), (BC, BC), (1, 0)
+    )
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+    b_gk = tl.load(p_gk, boundary_check=(0, 1)).to(tl.float32)
+
+    g_max = tl.max(b_g, axis=0)
+    g_min = tl.min(b_g, axis=0)
+    g_mid = 0.5 * (g_max + g_min)
+    b_qg = b_q * exp2(b_g - g_mid[None, :])
+    b_kg = b_k * exp2(-b_gk + g_mid[None, :])
+    b_A = tl.dot(b_qg, tl.trans(b_kg)) * scale
+    b_A = tl.where(m_s, b_A, 0.0)
+    tl.store(p_A, b_A.to(p_A.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=1),
+        triton.Config({}, num_warps=2),
+        triton.Config({}, num_warps=4),
+        triton.Config({}, num_warps=8),
+    ],
+    key=["BC"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_A_kernel_intra_sub_intra_merge(
+    A,
+    A2,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    NK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_c, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+        all = B * T
+
+    if i_t * BT + i_c * BC >= T:
+        return
+
+    b_A = tl.zeros([BC, BC], dtype=tl.float32)
+    for i_k in range(0, NK):
+        p_A = tl.make_block_ptr(
+            A + (i_k * all + bos) * H * BC + i_h * BC,
+            (T, BC),
+            (H * BC, 1),
+            (i_t * BT + i_c * BC, 0),
+            (BC, BC),
+            (1, 0),
+        )
+        b_A += tl.load(p_A, boundary_check=(0, 1))
+    p_A2 = tl.make_block_ptr(
+        A2 + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + i_c * BC, i_c * BC),
+        (BC, BC),
+        (1, 0),
+    )
+    tl.store(p_A2, b_A.to(A2.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BK": BK, "BV": BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in [32, 64]
+        for BV in [64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "HV", "STATE_V_FIRST", "V"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_fwd_kernel_o(
+    q,
+    v,
+    g,
+    h,
+    o,
+    A,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_hv = i_bh // HV, i_bh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        i_tg = i_t.to(tl.int64)
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = (i_b * NT + i_t).to(tl.int64)
+        bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+    q += (bos * H + i_h) * K
+    g += (bos * HV + i_hv) * K
+    v += (bos * HV + i_hv) * V
+    o += (bos * HV + i_hv) * V
+    h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+    A += (bos * HV + i_hv) * BT
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+        )
+        p_g = tl.make_block_ptr(
+            g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+        )
+        if STATE_V_FIRST:
+            p_h = tl.make_block_ptr(
+                h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+        else:
+            p_h = tl.make_block_ptr(
+                h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
+
+        # [BT, BK]
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        # [BT, BK]
+        b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+        # [BT, BK]
+        b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        if i_k >= 0:
+            if STATE_V_FIRST:
+                b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+            else:
+                b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+    b_o *= scale
+    p_v = tl.make_block_ptr(
+        v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    p_o = tl.make_block_ptr(
+        o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+    )
+    p_A = tl.make_block_ptr(A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0))
+    # [BT, BV]
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    # [BT, BT]
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+    b_o += tl.dot(b_A, b_v)
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+if HAS_TLE:
+
+    @triton.heuristics(
+        {
+            "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        }
+    )
+    @triton.autotune(
+        configs=[
+            triton.Config(
+                {"BK": BK, "BV": BV, "B_VCHUNK": B_VCHUNK},
+                num_warps=num_warps,
+                num_stages=num_stages,
+            )
+            for BK in [32, 64]
+            for BV in [64, 128]
+            for B_VCHUNK in [1, 2, 4]
+            for num_warps in [2, 4, 8]
+            for num_stages in [2, 3, 4]
+        ],
+        key=["BT", "HV", "STATE_V_FIRST", "V"],
+    )
+    @triton.jit(do_not_specialize=["T"])
+    def chunk_gla_fwd_kernel_o_tle(
+        q,
+        v,
+        g,
+        h,
+        o,
+        A,
+        cu_seqlens,
+        chunk_indices,
+        scale,
+        T,
+        H: tl.constexpr,
+        HV: tl.constexpr,
+        K: tl.constexpr,
+        V: tl.constexpr,
+        BT: tl.constexpr,
+        BK: tl.constexpr,
+        BV: tl.constexpr,
+        B_VCHUNK: tl.constexpr,
+        STATE_V_FIRST: tl.constexpr,
+        IS_VARLEN: tl.constexpr,
+    ):
+        i_vg, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+        i_v_base = i_vg * B_VCHUNK
+        i_b, i_hv = i_bh // HV, i_bh % HV
+        i_h = i_hv // (HV // H)
+        if IS_VARLEN:
+            i_tg = i_t.to(tl.int64)
+            i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+                chunk_indices + i_t * 2 + 1
+            ).to(tl.int32)
+            bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+                cu_seqlens + i_n + 1
+            ).to(tl.int64)
+            T = eos - bos
+            NT = tl.cdiv(T, BT)
+        else:
+            NT = tl.cdiv(T, BT)
+            i_tg = (i_b * NT + i_t).to(tl.int64)
+            bos, eos = (i_b * T).to(tl.int64), (i_b * T + T).to(tl.int64)
+
+        m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+
+        q += (bos * H + i_h) * K
+        g += (bos * HV + i_hv) * K
+        v += (bos * HV + i_hv) * V
+        o += (bos * HV + i_hv) * V
+        h += (i_tg * HV + i_hv).to(tl.int64) * K * V
+        A += (bos * HV + i_hv) * BT
+
+        n_k_tiles = tl.cdiv(K, BK)
+
+        if B_VCHUNK <= 1:
+            i_v = i_v_base
+            b_o = tl.zeros([BT, BV], dtype=tl.float32)
+            for i_k in range(n_k_tiles):
+                p_q = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                p_g = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                if STATE_V_FIRST:
+                    p_h = tl.make_block_ptr(
+                        h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+                    )
+                else:
+                    p_h = tl.make_block_ptr(
+                        h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+                    )
+
+                b_q = tle.load(p_q, boundary_check=(0, 1), is_async=True)
+                b_g = tle.load(p_g, boundary_check=(0, 1), is_async=True).to(tl.float32)
+                b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+                b_h = tle.load(p_h, boundary_check=(0, 1), is_async=True)
+
+                if STATE_V_FIRST:
+                    b_o += tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+                else:
+                    b_o += tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+            b_o *= scale
+            p_v = tl.make_block_ptr(
+                v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            p_o = tl.make_block_ptr(
+                o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+            )
+            p_A = tl.make_block_ptr(
+                A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+            )
+
+            b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+            b_A = tle.load(p_A, boundary_check=(0, 1), is_async=True)
+            b_A = tl.where(m_s, b_A, 0.0).to(b_v.dtype)
+            b_o += tl.dot(b_A, b_v)
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+        else:
+            b_o_0 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_1 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_2 = tl.zeros([BT, BV], dtype=tl.float32)
+            b_o_3 = tl.zeros([BT, BV], dtype=tl.float32)
+
+            for i_k in range(n_k_tiles):
+                p_q = tl.make_block_ptr(
+                    q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+                p_g = tl.make_block_ptr(
+                    g, (T, K), (HV * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+                )
+
+                b_q = tle.load(p_q, boundary_check=(0, 1), is_async=True)
+                b_g = tle.load(p_g, boundary_check=(0, 1), is_async=True).to(tl.float32)
+                b_qg = (b_q * exp2(b_g)).to(b_q.dtype)
+
+                for d in tl.static_range(B_VCHUNK):
+                    i_v = i_v_base + d
+
+                    if STATE_V_FIRST:
+                        p_h = tl.make_block_ptr(
+                            h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+                        )
+                    else:
+                        p_h = tl.make_block_ptr(
+                            h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+                        )
+
+                    b_h = tle.load(p_h, boundary_check=(0, 1), is_async=True)
+
+                    if STATE_V_FIRST:
+                        dot_res = tl.dot(b_qg, tl.trans(b_h).to(b_qg.dtype))
+                    else:
+                        dot_res = tl.dot(b_qg, b_h.to(b_qg.dtype))
+
+                    if d == 0:
+                        b_o_0 += dot_res
+                    elif d == 1:
+                        b_o_1 += dot_res
+                    elif d == 2:
+                        b_o_2 += dot_res
+                    elif d == 3:
+                        b_o_3 += dot_res
+
+            p_A = tl.make_block_ptr(
+                A, (T, BT), (HV * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+            )
+            b_A = tle.load(p_A, boundary_check=(0, 1), is_async=True)
+            b_A = tl.where(m_s, b_A, 0.0)
+
+            for d in tl.static_range(B_VCHUNK):
+                i_v = i_v_base + d
+
+                if d == 0:
+                    b_o_final = b_o_0
+                elif d == 1:
+                    b_o_final = b_o_1
+                elif d == 2:
+                    b_o_final = b_o_2
+                elif d == 3:
+                    b_o_final = b_o_3
+                else:
+                    b_o_final = b_o_0
+
+                b_o_final = b_o_final * scale
+
+                p_v = tl.make_block_ptr(
+                    v, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+                )
+                b_v = tle.load(p_v, boundary_check=(0, 1), is_async=True)
+                b_o_final += tl.dot(b_A.to(b_v.dtype), b_v)
+
+                p_o = tl.make_block_ptr(
+                    o, (T, V), (HV * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+                )
+                tl.store(p_o, b_o_final.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BK", "NC", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_bwd_kernel_intra(
+    q,
+    k,
+    g,
+    dA,
+    dq,
+    dk,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    NC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_kc, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    i_k, i_i = i_kc // NC, i_kc % NC
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+    if i_t * BT + i_i * BC >= T:
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+
+    p_g = tl.make_block_ptr(
+        g + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
+    # [BC, BK]
+    b_g = tl.load(p_g, boundary_check=(0, 1))
+
+    b_dq = tl.zeros([BC, BK], dtype=tl.float32)
+    if i_i > 0:
+        p_gn = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        for i_j in range(0, i_i):
+            p_k = tl.make_block_ptr(
+                k + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_gk = tl.make_block_ptr(
+                g + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_dA = tl.make_block_ptr(
+                dA + (bos * H + i_h) * BT,
+                (T, BT),
+                (H * BT, 1),
+                (i_t * BT + i_i * BC, i_j * BC),
+                (BC, BC),
+                (1, 0),
+            )
+            # [BC, BK]
+            b_k = tl.load(p_k, boundary_check=(0, 1))
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_kg = b_k * exp2(b_gn[None, :] - b_gk)
+            # [BC, BC]
+            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+
+            b_dq += tl.dot(b_dA, b_kg)
+        b_dq *= exp2(b_g - b_gn[None, :])
+    o_i = tl.arange(0, BC)
+    m_dA = (i_t * BT + i_i * BC + tl.arange(0, BC)) < T
+    o_dA = (
+        bos * H * BT
+        + (i_t * BT + i_i * BC + tl.arange(0, BC)) * H * BT
+        + i_h * BT
+        + i_i * BC
+    )
+    p_kj = k + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gkj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_dq = tl.make_block_ptr(
+        dq + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
+
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        # [BC,]
+        b_dA = tl.load(dA + o_dA + j, mask=m_dA, other=0)
+        # [BK,]
+        b_kj = tl.load(p_kj, mask=m_k, other=0).to(tl.float32)
+        b_gkj = tl.load(p_gkj, mask=m_k, other=0).to(tl.float32)
+        # [BC, BK]
+        m_i = o_i[:, None] >= j
+        # [BC, BK]
+        # (SY 09/17) important to not use bf16 here to have a good precision.
+        b_dq += tl.where(
+            m_i, b_dA[:, None] * b_kj[None, :] * exp2(b_g - b_gkj[None, :]), 0.0
+        )
+        p_kj += H * K
+        p_gkj += H * K
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+
+    # tl.debug_barrier()
+    # [BC, BK]
+    b_dk = tl.zeros([BC, BK], dtype=tl.float32)
+
+    NC = min(NC, tl.cdiv(T - i_t * BT, BC))
+    if i_i < NC - 1:
+        p_gn = g + (bos + min(i_t * BT + i_i * BC + BC, T) - 1) * H * K + i_h * K + o_k
+
+        # [BK,]
+        b_gn = tl.load(p_gn, mask=m_k, other=0)
+        for i_j in range(i_i + 1, NC):
+            p_q = tl.make_block_ptr(
+                q + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_gq = tl.make_block_ptr(
+                g + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_j * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_dA = tl.make_block_ptr(
+                dA + (bos * H + i_h) * BT,
+                (BT, T),
+                (1, H * BT),
+                (i_i * BC, i_t * BT + i_j * BC),
+                (BC, BC),
+                (0, 1),
+            )
+
+            o_j = i_t * BT + i_j * BC + o_i
+            m_j = o_j < T
+            # [BC, BK]
+            b_q = tl.load(p_q, boundary_check=(0, 1))
+            b_gq = tl.load(p_gq, boundary_check=(0, 1))
+            b_qg = b_q * tl.where(m_j[:, None], exp2(b_gq - b_gn[None, :]), 0)
+            # [BC, BC]
+            b_dA = tl.load(p_dA, boundary_check=(0, 1))
+            # [BC, BK]
+            # (SY 09/17) important to not use bf16 here to have a good precision.
+            b_dk += tl.dot(b_dA, b_qg)
+        b_dk *= exp2(b_gn[None, :] - b_g)
+    o_dA = (
+        bos * H * BT
+        + (i_t * BT + i_i * BC) * H * BT
+        + i_h * BT
+        + i_i * BC
+        + tl.arange(0, BC)
+    )
+    p_qj = q + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_gqj = g + (bos + i_t * BT + i_i * BC) * H * K + i_h * K + o_k
+    p_dk = tl.make_block_ptr(
+        dk + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT + i_i * BC, i_k * BK),
+        (BC, BK),
+        (1, 0),
+    )
+    for j in range(0, min(BC, T - i_t * BT - i_i * BC)):
+        # [BC,]
+        b_dA = tl.load(dA + o_dA + j * H * BT)
+        # [BK,]
+        b_qj = tl.load(p_qj, mask=m_k, other=0).to(tl.float32)
+        b_gqj = tl.load(p_gqj, mask=m_k, other=0).to(tl.float32)
+        # [BC, BK]
+        m_i = o_i[:, None] <= j
+        b_dk += tl.where(
+            m_i, b_dA[:, None] * b_qj[None, :] * exp2(b_gqj[None, :] - b_g), 0.0
+        )
+        p_qj += H * K
+        p_gqj += H * K
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for num_warps in [1, 2, 4]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BV", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_bwd_kernel_dA(
+    v,
+    do,
+    dA,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    T = eos - bos
+
+    b_dA = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_v in range(tl.cdiv(V, BV)):
+        p_do = tl.make_block_ptr(
+            do + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (V, T),
+            (1, H * V),
+            (i_v * BV, i_t * BT),
+            (BV, BT),
+            (0, 1),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+
+        b_dA += tl.dot(b_do, b_v)
+
+    p_dA = tl.make_block_ptr(
+        dA + (bos * H + i_h) * BT, (T, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+    b_dA = tl.where(m_s, b_dA * scale, 0.0)
+    tl.store(p_dA, b_dA.to(p_dA.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BK": BK, "BV": BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "K", "V", "STATE_V_FIRST"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_bwd_kernel_dv(
+    k,
+    g,
+    A,
+    do,
+    dh,
+    dv,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    p_A = tl.make_block_ptr(
+        A + (bos * H + i_h) * BT, (BT, T), (1, H * BT), (0, i_t * BT), (BT, BT), (0, 1)
+    )
+    p_do = tl.make_block_ptr(
+        do + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_dv = tl.make_block_ptr(
+        dv + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    b_A = tl.load(p_A, boundary_check=(0, 1))
+    b_do = tl.load(p_do, boundary_check=(0, 1))
+
+    b_A = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], b_A, 0.0)
+    # (SY 09/17) important to disallow tf32 here to maintain a good precision.
+    b_dv = tl.dot(b_A, b_do.to(b_A.dtype), allow_tf32=False)
+
+    for i_k in range(tl.cdiv(K, BK)):
+        o_k = i_k * BK + tl.arange(0, BK)
+        m_k = o_k < K
+
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_gk = tl.make_block_ptr(
+            g + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_gn = g + (bos + min(i_t * BT + BT, T) - 1) * H * K + i_h * K + o_k
+        if STATE_V_FIRST:
+            # dh stored as [V, K]; read a logical [BK, BV] tile via on-the-fly transpose
+            p_dh = tl.make_block_ptr(
+                dh + (i_tg * H + i_h) * K * V,
+                (K, V),
+                (1, K),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (0, 1),
+            )
+        else:
+            p_dh = tl.make_block_ptr(
+                dh + (i_tg * H + i_h) * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
+
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_gk = tl.load(p_gk, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+
+        b_gn = exp2(tl.load(p_gn, mask=m_k, other=0)[None, :] - b_gk)
+        b_k = (b_k * b_gn).to(b_k.dtype)
+        # [BT, BV]
+        # (SY 09/17) it is ok to have bf16 interchunk gradient contribution here
+        b_dv += tl.dot(b_k, b_dh.to(b_k.dtype))
+
+    tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config(
+            {"BK": BK, "BV": BV},
+            num_warps=num_warps,
+            num_stages=num_stages,
+        )
+        for BK in BK_LIST
+        for BV in BV_LIST
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "K", "V", "STATE_V_FIRST"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gla_bwd_kernel_inter(
+    q,
+    k,
+    v,
+    g,
+    h,
+    do,
+    dh,
+    dq,
+    dk,
+    dq2,
+    dk2,
+    dg,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+    o_k = i_k * BK + tl.arange(0, BK)
+    m_k = o_k < K
+
+    q += (bos * H + i_h) * K
+    k += (bos * H + i_h) * K
+    v += (bos * H + i_h) * V
+    g += (bos * H + i_h) * K
+    h += (i_tg * H + i_h) * K * V
+    do += (bos * H + i_h) * V
+    dh += (i_tg * H + i_h) * K * V
+    dq += (bos * H + i_h) * K
+    dk += (bos * H + i_h) * K
+    dq2 += (bos * H + i_h) * K
+    dk2 += (bos * H + i_h) * K
+    dg += (bos * H + i_h) * K
+
+    p_gk = tl.make_block_ptr(
+        g, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    b_gk = tl.load(p_gk, boundary_check=(0, 1))
+    p_gn = g + (min(T, i_t * BT + BT) - 1) * H * K + o_k
+    b_gn = tl.load(p_gn, mask=m_k, other=0)
+    b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dgk = tl.zeros([BK], dtype=tl.float32)
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_do = tl.make_block_ptr(
+            do, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        if STATE_V_FIRST:
+            # h / dh stored as [V, K] -- the [BV, BK] tile is now a contiguous read
+            p_h = tl.make_block_ptr(
+                h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+            p_dh = tl.make_block_ptr(
+                dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+        else:
+            p_h = tl.make_block_ptr(
+                h, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+            )
+            p_dh = tl.make_block_ptr(
+                dh, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+            )
+        # [BT, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        # [BV, BK]
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+
+        # [BK]
+        b_dgk += tl.sum(b_h * b_dh, axis=0)
+        # [BT, BK]
+        b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+        b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
+
+    b_dgk *= exp2(b_gn)
+    b_dq *= scale
+    b_dq = b_dq * exp2(b_gk)
+    b_dk = b_dk * exp2(b_gn[None, :] - b_gk)
+    p_q = tl.make_block_ptr(
+        q, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dq = tl.make_block_ptr(
+        dq, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dk = tl.make_block_ptr(
+        dk, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_dgk += tl.sum(b_dk * b_k, axis=0)
+    b_dq += tl.load(p_dq, boundary_check=(0, 1))
+    b_dk += tl.load(p_dk, boundary_check=(0, 1))
+    b_dg = b_q * b_dq - b_k * b_dk
+    # tl.debug_barrier()
+    b_dg = (
+        b_dg - tl.cumsum(b_dg, axis=0) + tl.sum(b_dg, axis=0)[None, :] + b_dgk[None, :]
+    )
+    # Buggy due to strange triton compiler issue.
+    # m_s = tl.where(tl.arange(0, BT)[:, None] <= tl.arange(0, BT)[None, :], 1., 0.)
+    # b_dg = tl.dot(m_s, b_dg, allow_tf32=False) + b_dgk[None, :]
+    p_dq = tl.make_block_ptr(
+        dq2, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dk = tl.make_block_ptr(
+        dk2, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_dg = tl.make_block_ptr(
+        dg, (T, K), (H * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_gla_fwd_intra_gk(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = k.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BC = min(16, BT)
+    NC = triton.cdiv(BT, BC)
+
+    A = q.new_empty(B, T, H, BT, dtype=torch.float)
+    grid = (NT, NC * NC, B * H)
+    chunk_gla_fwd_A_kernel_intra_sub_inter[grid](
+        q=q,
+        k=k,
+        g=g,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        NC=NC,
+    )
+
+    grid = (NT, NC, B * H)
+    # load the entire [BC, K] blocks into SRAM at once
+    if K <= 256:
+        BK = max(triton.next_power_of_2(K), 16)
+        chunk_gla_fwd_A_kernel_intra_sub_intra[grid](
+            q=q,
+            k=k,
+            g=g,
+            A=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            scale=scale,
+            T=T,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+        )
+    # split then merge
+    else:
+        BK = min(128, triton.next_power_of_2(K))
+        NK = triton.cdiv(K, BK)
+        A_intra = q.new_empty(NK, B, T, H, BC, dtype=torch.float)
+
+        grid = (NK, NT * NC, B * H)
+        chunk_gla_fwd_A_kernel_intra_sub_intra_split[grid](
+            q=q,
+            k=k,
+            g=g,
+            A=A_intra,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            scale=scale,
+            T=T,
+            B=B,
+            H=H,
+            K=K,
+            BT=BT,
+            BC=BC,
+            BK=BK,
+            NC=NC,
+        )
+
+        grid = (NT, NC, B * H)
+        chunk_gla_fwd_A_kernel_intra_sub_intra_merge[grid](
+            A=A_intra,
+            A2=A,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            B=B,
+            H=H,
+            BT=BT,
+            BC=BC,
+            NK=NK,
+        )
+    return A
+
+
+def chunk_gla_fwd_o_gk(
+    q: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    h: torch.Tensor,
+    scale: float,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, HV, V = *q.shape, v.shape[2], v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    # Please ensure zeros, since vllm will use padding v
+    o = torch.zeros_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * HV)
+
+    def grid_tle(meta):
+        return (triton.cdiv(V, meta["BV"] * meta.get("B_VCHUNK", 1)), NT, B * HV)
+
+    _use_tle = HAS_TLE and os.environ.get("FLAG_ATTN_GLA_TLE", "1") != "0"
+    if _use_tle:
+        kernel = chunk_gla_fwd_kernel_o_tle
+        grid_fn = grid_tle
+    else:
+        kernel = chunk_gla_fwd_kernel_o
+        grid_fn = grid
+    kernel[grid_fn](
+        q=q,
+        v=v,
+        g=g,
+        h=h,
+        o=o,
+        A=A,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        HV=HV,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return o
+
+
+def chunk_gla_bwd_dA(
+    v: torch.Tensor,
+    do: torch.Tensor,
+    scale: float,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, V = v.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BV = min(64, triton.next_power_of_2(V))
+
+    dA = v.new_empty(B, T, H, BT, dtype=torch.float)
+    grid = (NT, B * H)
+    chunk_gla_bwd_kernel_dA[grid](
+        v=v,
+        do=do,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        V=V,
+        BT=BT,
+        BV=BV,
+    )
+    return dA
+
+
+def chunk_gla_bwd_dv(
+    k: torch.Tensor,
+    g: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, do.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dv = torch.empty_like(do)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_gla_bwd_kernel_dv[grid](
+        k=k,
+        g=g,
+        A=A,
+        do=do,
+        dh=dh,
+        dv=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dv
+
+
+def chunk_gla_bwd_dqk_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    dA: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K = q.shape
+    BT = chunk_size
+    BC = min(16, BT)
+    BK = min(64, triton.next_power_of_2(K))
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NC = triton.cdiv(BT, BC)
+    NK = triton.cdiv(K, BK)
+
+    dq = torch.empty_like(q, dtype=torch.float)
+    dk = torch.empty_like(k, dtype=torch.float)
+    grid = (NK * NC, NT, B * H)
+    chunk_gla_bwd_kernel_intra[grid](
+        q=q,
+        k=k,
+        g=g,
+        dA=dA,
+        dq=dq,
+        dk=dk,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+        NC=NC,
+    )
+    return dq, dk
+
+
+def chunk_gla_bwd_dqkg(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    h: torch.Tensor,
+    g: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dq: torch.Tensor,
+    dk: torch.Tensor,
+    scale: float | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    dg = torch.empty_like(g)
+    dq2 = torch.empty_like(dq)
+    dk2 = torch.empty_like(dk)
+
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), NT, B * H)
+
+    chunk_gla_bwd_kernel_inter[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        h=h,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        dq2=dq2,
+        dk2=dk2,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dq2, dk2, dg
+
+
+def chunk_gla_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_cumsum: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    output_final_state: bool,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if g_cumsum is None:
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+        )
+
+    h, ht = chunk_fwd_h(
+        k=k,
+        v=v,
+        g=None,
+        gk=g_cumsum,
+        gv=None,
+        h0=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        states_in_fp32=False,
+        state_v_first=state_v_first,
+    )
+
+    # the intra A is kept in fp32
+    # the computation has very marginal effect on the entire throughput
+    A = chunk_gla_fwd_intra_gk(
+        q=q,
+        k=k,
+        g=g_cumsum,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    o = chunk_gla_fwd_o_gk(
+        q=q,
+        v=v,
+        g=g_cumsum,
+        A=A,
+        h=h,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+    return g_cumsum, A, h, ht, o
+
+
+def chunk_gla_bwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    g_cumsum: torch.Tensor | None,
+    scale: float,
+    initial_state: torch.Tensor,
+    h: torch.Tensor,
+    A: torch.Tensor,
+    do: torch.Tensor,
+    dht: torch.Tensor,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.LongTensor | None = None,
+):
+    if g_cumsum is None:
+        g_cumsum = chunk_local_cumsum(
+            g,
+            chunk_size,
+            scale=RCP_LN2,
+            cu_seqlens=cu_seqlens,
+        )
+
+    if h is None:
+        h, _ = chunk_fwd_h(
+            k=k,
+            v=v,
+            g=None,
+            gk=g_cumsum,
+            gv=None,
+            h0=initial_state,
+            output_final_state=False,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            states_in_fp32=True,
+            state_v_first=state_v_first,
+        )
+    dh, dh0 = chunk_bwd_dh(
+        q=q,
+        k=k,
+        v=v,
+        g=None,
+        gk=g_cumsum,
+        gv=None,
+        do=do,
+        h0=initial_state,
+        dht=dht,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        states_in_fp32=True,
+        state_v_first=state_v_first,
+    )
+
+    dv = chunk_gla_bwd_dv(
+        k=k,
+        g=g_cumsum,
+        A=A,
+        do=do,
+        dh=dh,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+
+    # dq dk in fp32
+    dA = chunk_gla_bwd_dA(
+        v=v,
+        do=do,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    dq, dk = chunk_gla_bwd_dqk_intra(
+        q=q,
+        k=k,
+        g=g_cumsum,
+        dA=dA,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+    dq, dk, dg = chunk_gla_bwd_dqkg(
+        q=q,
+        k=k,
+        v=v,
+        h=h,
+        g=g_cumsum,
+        do=do,
+        dh=dh,
+        dq=dq,
+        dk=dk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        state_v_first=state_v_first,
+    )
+    return dq, dk, dv, dg, dh0
+
+
+class ChunkGLAFunction(torch.autograd.Function):
+
+    @staticmethod
+    @input_guard
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        state_v_first,
+        cu_seqlens,
+        cu_seqlens_cpu,
+    ):
+        chunk_size = min(64, max(16, triton.next_power_of_2(q.shape[1])))
+        if cu_seqlens is not None:
+            chunk_indices = prepare_chunk_indices(
+                cu_seqlens,
+                chunk_size,
+                cu_seqlens_cpu=cu_seqlens_cpu,
+            )
+        else:
+            chunk_indices = None
+
+        g_cumsum, A, _, ht, o = chunk_gla_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_cumsum=None,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            state_v_first=state_v_first,
+        )
+        # recompute g_cumsum in bwd pass
+        if g.dtype != torch.float:
+            g_cumsum = None
+        else:
+            g = None
+        ctx.save_for_backward(q, k, v, g, g_cumsum, initial_state, A, chunk_indices)
+        ctx.chunk_size = chunk_size
+        ctx.scale = scale
+        ctx.cu_seqlens = cu_seqlens
+        ctx.state_v_first = state_v_first
+        return o, ht
+
+    @staticmethod
+    @input_guard
+    def backward(ctx, do, dht):
+        q, k, v, g, g_cumsum, initial_state, A, chunk_indices = ctx.saved_tensors
+        chunk_size, scale, cu_seqlens = ctx.chunk_size, ctx.scale, ctx.cu_seqlens
+        dq, dk, dv, dg, dh0 = chunk_gla_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_cumsum=g_cumsum,
+            scale=scale,
+            h=None,
+            A=A,
+            initial_state=initial_state,
+            do=do,
+            dht=dht,
+            cu_seqlens=cu_seqlens,
+            chunk_size=chunk_size,
+            chunk_indices=chunk_indices,
+            state_v_first=ctx.state_v_first,
+        )
+        return dq.to(q), dk.to(k), dv.to(v), dg, None, dh0, None, None, None, None
+
+
+@torch.compiler.disable
+def chunk_gla(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    scale: int | None = None,
+    initial_state: torch.Tensor = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""
+    Args:
+        q (torch.Tensor):
+            queries of shape `[B, T, H, K]`.
+        k (torch.Tensor):
+            keys of shape `[B, T, H, K]`.
+        v (torch.Tensor):
+            values of shape `[B, T, H, V]`.
+        g (torch.Tensor):
+            Forget gates of shape `[B, T, H, K]`.
+        scale (Optional[float]):
+            Scale factor for the attention scores.
+            If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
+        initial_state (Optional[torch.Tensor]):
+            Initial state of shape `[N, H, K, V]` (or `[N, H, V, K]` if `state_v_first=True`)
+            for `N` input sequences.
+            For equal-length input sequences, `N` equals the batch size `B`.
+            Default: `None`.
+        output_final_state (Optional[bool]):
+            Whether to output the final state of shape `[N, H, K, V]`
+            (or `[N, H, V, K]` if `state_v_first=True`). Default: `False`.
+        state_v_first (Optional[bool]):
+            Store the recurrent state in V-first `[V, K]` layout instead of the default `[K, V]`. Default: `False`.
+        cu_seqlens (torch.LongTensor):
+            Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
+            consistent with the FlashAttention API.
+
+    Returns:
+        o (torch.Tensor):
+            Outputs of shape `[B, T, H, V]`.
+        final_state (torch.Tensor):
+            Final state of shape `[N, H, K, V]` (or `[N, H, V, K]` if `state_v_first=True`)
+            if `output_final_state=True` else `None`.
+
+    Examples::
+        >>> import torch
+        >>> import torch.nn.functional as F
+        >>> from einops import rearrange
+        >>> from flag_attn import chunk_gla
+        # inputs with equal lengths
+        >>> B, T, H, K, V = 4, 2048, 4, 512, 512
+        >>> q = torch.randn(B, T, H, K, device='cuda')
+        >>> k = torch.randn(B, T, H, K, device='cuda')
+        >>> v = torch.randn(B, T, H, V, device='cuda')
+        >>> g = F.logsigmoid(torch.randn(B, T, H, K, device='cuda'))
+        >>> h0 = torch.randn(B, H, K, V, device='cuda')
+        >>> o, ht = chunk_gla(
+            q, k, v, g,
+            initial_state=h0,
+            output_final_state=True
+        )
+        # for variable-length inputs, the batch size `B` is expected to be 1 and `cu_seqlens` is required
+        >>> q, k, v, g = map(lambda x: rearrange(x, 'b t h d -> 1 (b t) h d'), (q, k, v, g))
+        # for a batch with 4 sequences, `cu_seqlens` with 5 start/end positions are expected
+        >>> cu_seqlens = q.new_tensor([0, 2048, 4096, 6144, 8192], dtype=torch.long)
+        >>> o, ht = chunk_gla(
+            q, k, v, g,
+            initial_state=h0,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens
+        )
+    """
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {q.shape[0]} when using `cu_seqlens`."
+                f"Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    if initial_state is not None:
+        assert initial_state.dtype == torch.float32, "initial_state must be in float32."
+    assert q.shape == k.shape == g.shape, "q, k, g must have the same shape."
+    assert v.shape == (
+        *q.shape[:3],
+        v.shape[-1],
+    ), "v must be of shape (batch size, seq len, num of head, head dim)."
+    o, final_state = ChunkGLAFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        state_v_first,
+        cu_seqlens,
+        cu_seqlens_cpu,
+    )
+    return o, final_state

--- a/src/flag_attn/gated_linear_attention/chunk_h.py
+++ b/src/flag_attn/gated_linear_attention/chunk_h.py
@@ -1,0 +1,594 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+import torch
+import triton
+import triton.language as tl
+
+from .index import prepare_chunk_offsets
+from .utils import check_shared_mem
+
+BKV_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.jit
+def exp2(x):
+    return tl.math.exp2(x.to(tl.float32))
+
+
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "USE_G", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_fwd_kernel_h(
+    k,
+    v,
+    h,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    h0,
+    ht,
+    cu_seqlens,
+    split_offsets,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        NT, NS = tl.cdiv(T, BT), tl.cdiv(T, BS)
+        boh = tl.load(split_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT, NS = tl.cdiv(T, BT), tl.cdiv(T, BS)
+        boh = i_n * NS
+    NTS = BS // BT
+
+    if USE_G_GAMMA:
+        # decay rate given the head index
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K]
+    # applied at the load/store below.
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = tl.make_block_ptr(
+                h0 + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            b_h = tl.trans(tl.load(p_h0, boundary_check=(0, 1))).to(tl.float32)
+        else:
+            p_h0 = tl.make_block_ptr(
+                h0 + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
+            b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_t in range(NT):
+        i_s = i_t // NTS
+        p_k = tl.make_block_ptr(
+            k + (bos * H + i_h) * K,
+            (K, T),
+            (1, H * K),
+            (i_k * BK, i_t * BT),
+            (BK, BT),
+            (0, 1),
+        )
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+
+        o_h = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        if STATE_V_FIRST:
+            p_h = tl.make_block_ptr(
+                h + o_h, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+        else:
+            p_h = tl.make_block_ptr(
+                h + o_h, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
+
+        if i_t % NTS == 0:
+            tl.store(
+                p_h,
+                (tl.trans(b_h) if STATE_V_FIRST else b_h).to(p_h.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
+        # [BK, BT]
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        # [BT, BV]
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        last_idx = min((i_t + 1) * BT, T) - 1
+
+        # scalar decay
+        if USE_G:
+            b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+            p_g = g + bos * H + (i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
+            b_h *= exp2(b_g_last)
+            b_v = (b_v * exp2(b_g_last - b_g)[:, None]).to(b_v.dtype)
+
+        # vector decay, h = Diag(gk) @ h
+        if USE_GK:
+            p_gk = tl.make_block_ptr(
+                gk + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT),
+                (BK, BT),
+                (0, 1),
+            )
+            p_gk_last = (
+                gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            )
+
+            b_gk_last = tl.load(
+                p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
+            )
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_h *= exp2(b_gk_last)[:, None]
+            b_k = (b_k * exp2(b_gk_last[:, None] - b_gk)).to(b_k.dtype)
+
+        # vector decay, h = h @ Diag(gv)
+        if USE_GV:
+            p_gv = tl.make_block_ptr(
+                gv + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_gv_last = (
+                gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            )
+
+            b_gv_last = tl.load(
+                p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
+            )
+            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_h *= exp2(b_gv_last)[None, :]
+            b_v = (b_v * exp2(b_gv_last[None, :] - b_gv)).to(b_v.dtype)
+
+        b_h += tl.dot(b_k, b_v)
+
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht = tl.make_block_ptr(
+                ht + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            tl.store(
+                p_ht, tl.trans(b_h).to(p_ht.dtype.element_ty), boundary_check=(0, 1)
+            )
+        else:
+            p_ht = tl.make_block_ptr(
+                ht + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "STORE_INITIAL_STATE_GRADIENT": lambda args: args["dh0"] is not None,
+        "USE_FINAL_STATE_GRADIENT": lambda args: args["dht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BKV_LIST
+        for BV in BKV_LIST
+        for num_warps in [1, 2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "USE_G", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_bwd_kernel_dh(
+    q,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    do,
+    dh,
+    dht,
+    dh0,
+    cu_seqlens,
+    split_offsets,
+    scale,
+    T,
+    HQ: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    NG: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
+    USE_FINAL_STATE_GRADIENT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hq = i_nh // HQ, i_nh % HQ
+    i_h = i_hq // NG
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        NS = tl.cdiv(T, BS)
+        boh = tl.load(split_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        NS = tl.cdiv(T, BS)
+        boh = i_n * NS
+
+    if USE_G_GAMMA:
+        b_gamma = tl.load(g_gamma + i_h)
+        b_g = b_gamma * (tl.arange(0, BT) + 1)
+
+    # [BK, BV] accumulator; STATE_V_FIRST only flips the stored state's HBM layout to [V, K]
+    # applied at the load/store below.
+    b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_FINAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dht = tl.make_block_ptr(
+                dht + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            b_dh += tl.trans(tl.load(p_dht, boundary_check=(0, 1))).to(tl.float32)
+        else:
+            p_dht = tl.make_block_ptr(
+                dht + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
+            b_dh += tl.load(p_dht, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_t in range(NT - 1, -1, -1):
+        i_s = i_t // (BS // BT)
+        o_dh = ((boh + i_s) * H + i_h).to(tl.int64) * K * V
+        if STATE_V_FIRST:
+            p_dh = tl.make_block_ptr(
+                dh + o_dh, (V, K), (K, 1), (i_v * BV, i_k * BK), (BV, BK), (1, 0)
+            )
+        else:
+            p_dh = tl.make_block_ptr(
+                dh + o_dh, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+            )
+
+        if i_t % (BS // BT) == 0:
+            tl.store(
+                p_dh,
+                (tl.trans(b_dh) if STATE_V_FIRST else b_dh).to(p_dh.dtype.element_ty),
+                boundary_check=(0, 1),
+            )
+        last_idx = min(i_t * BT + BT, T) - 1
+        # [BK, BT]
+        p_q = tl.make_block_ptr(
+            q + (bos * HQ + i_hq) * K,
+            (K, T),
+            (1, HQ * K),
+            (i_k * BK, i_t * BT),
+            (BK, BT),
+            (0, 1),
+        )
+        p_do = tl.make_block_ptr(
+            do + (bos * HQ + i_hq) * V,
+            (T, V),
+            (HQ * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_q.dtype)
+        # [BT, BV]
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+
+        if USE_G:
+            p_g = g + (bos + i_t * BT + tl.arange(0, BT)) * H + i_h
+            b_g_last = tl.load(g + (bos + last_idx) * H + i_h)
+            b_g = tl.load(p_g, mask=(i_t * BT + tl.arange(0, BT) < T), other=0.0)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
+
+        if USE_G_GAMMA:
+            b_g_last = b_gamma * min(BT, T - i_t * BT)
+            b_q = (b_q * exp2(b_g)[None, :]).to(b_q.dtype)
+            b_dh *= exp2(b_g_last)
+
+        if USE_GK:
+            p_gk = tl.make_block_ptr(
+                gk + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT),
+                (BK, BT),
+                (0, 1),
+            )
+            p_gk_last = (
+                gk + (bos + last_idx) * H * K + i_h * K + i_k * BK + tl.arange(0, BK)
+            )
+
+            b_gk = tl.load(p_gk, boundary_check=(0, 1))
+            b_gk_last = tl.load(
+                p_gk_last, mask=(i_k * BK + tl.arange(0, BK) < K), other=0.0
+            )
+            b_q = (b_q * exp2(b_gk)).to(b_q.dtype)
+            b_dh *= exp2(b_gk_last)[:, None]
+
+        if USE_GV:
+            p_gv = tl.make_block_ptr(
+                gv + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT, i_v * BV),
+                (BT, BV),
+                (1, 0),
+            )
+            p_gv_last = (
+                gv + (bos + last_idx) * H * V + i_h * V + i_v * BV + tl.arange(0, BV)
+            )
+
+            b_gv = tl.load(p_gv, boundary_check=(0, 1))
+            b_gv_last = tl.load(
+                p_gv_last, mask=(i_v * BV + tl.arange(0, BV) < V), other=0.0
+            )
+            b_do = b_do * exp2(b_gv)
+            b_dh *= exp2(b_gv_last)[None, :]
+
+        b_dh += tl.dot(b_q, b_do.to(b_q.dtype))
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dh0 = tl.make_block_ptr(
+                dh0 + i_nh * K * V,
+                (V, K),
+                (K, 1),
+                (i_v * BV, i_k * BK),
+                (BV, BK),
+                (1, 0),
+            )
+            tl.store(
+                p_dh0, tl.trans(b_dh).to(p_dh0.dtype.element_ty), boundary_check=(0, 1)
+            )
+        else:
+            p_dh0 = tl.make_block_ptr(
+                dh0 + i_nh * K * V,
+                (K, V),
+                (V, 1),
+                (i_k * BK, i_v * BV),
+                (BK, BV),
+                (1, 0),
+            )
+            tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_fwd_h(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    h0: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert (
+        BS % BT == 0
+    ), f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    if cu_seqlens is None:
+        N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    else:
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+
+    # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
+    state_shape = (V, K) if state_v_first else (K, V)
+    h = k.new_empty(
+        B, NS, H, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float
+    )
+    ht = (
+        k.new_empty(N, H, *state_shape, dtype=torch.float)
+        if output_final_state
+        else None
+    )
+
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_fwd_kernel_h[grid](
+        k=k,
+        v=v,
+        h=h,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        h0=h0,
+        ht=ht,
+        cu_seqlens=cu_seqlens,
+        split_offsets=split_offsets,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BS=BS,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        STATE_V_FIRST=state_v_first,
+    )
+    return h, ht
+
+
+def chunk_bwd_dh(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    do: torch.Tensor,
+    h0: torch.Tensor,
+    dht: torch.Tensor,
+    scale: float,
+    g: torch.Tensor | None = None,
+    g_gamma: torch.Tensor | None = None,
+    gk: torch.Tensor | None = None,
+    gv: torch.Tensor | None = None,
+    state_v_first: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    split_size: int | None = None,
+    states_in_fp32: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HQ = q.shape[2]
+    BT = chunk_size
+    BS = BT if split_size is None else split_size
+    assert (
+        BS % BT == 0
+    ), f"The `split_size` (got {BS}) must be a multiple of `chunk_size` {BT}"
+    # N: the actual number of sequences in the batch with either equal or variable lengths
+    # NG: number of groups in GQA
+    if cu_seqlens is None:
+        N, NS, split_offsets = B, triton.cdiv(T, BS), None
+    else:
+        split_offsets = prepare_chunk_offsets(cu_seqlens, BS)
+        N, NS = len(cu_seqlens) - 1, split_offsets[-1].item()
+    NG = HQ // H
+
+    # `state_v_first` stores the states in V-first `[V, K]` layout instead of `[K, V]`
+    state_shape = (V, K) if state_v_first else (K, V)
+    dh = k.new_empty(
+        B, NS, HQ, *state_shape, dtype=k.dtype if not states_in_fp32 else torch.float
+    )
+    dh0 = torch.empty_like(h0, dtype=torch.float) if h0 is not None else None
+
+    def grid(meta):
+        return (triton.cdiv(K, meta["BK"]), triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_bwd_kernel_dh[grid](
+        q=q,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        do=do,
+        dh=dh,
+        dht=dht,
+        dh0=dh0,
+        cu_seqlens=cu_seqlens,
+        split_offsets=split_offsets,
+        scale=scale,
+        T=T,
+        HQ=HQ,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BS=BS,
+        NG=NG,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        STATE_V_FIRST=state_v_first,
+    )
+    return dh, dh0

--- a/src/flag_attn/gated_linear_attention/compat.py
+++ b/src/flag_attn/gated_linear_attention/compat.py
@@ -1,0 +1,32 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility helpers for running the GLA kernels without FlagGems."""
+
+from collections.abc import Sequence
+from typing import Any
+
+import triton
+
+
+def libtuner(
+    *,
+    configs: Sequence[triton.Config],
+    key: Sequence[str],
+    use_cuda_graph: bool = False,
+    **kwargs: Any,
+):
+    """Map FlagGems autotuning metadata to Triton's native autotuner."""
+    del use_cuda_graph
+    return triton.autotune(configs=list(configs), key=list(key), **kwargs)

--- a/src/flag_attn/gated_linear_attention/cumsum.py
+++ b/src/flag_attn/gated_linear_attention/cumsum.py
@@ -1,0 +1,566 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+
+import torch
+import triton
+import triton.language as tl
+
+from .compat import libtuner
+from .index import prepare_chunk_indices
+from .utils import check_shared_mem, input_guard
+
+BS_LIST = [32, 64] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8]],
+    key=["B", "H", "BT", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(
+            s + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+        )
+        p_o = tl.make_block_ptr(
+            o + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+        )
+    else:
+        p_s = tl.make_block_ptr(s + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        p_o = tl.make_block_ptr(o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    # [BT]
+    b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+    b_o = tl.cumsum(b_s, axis=0)
+    if REVERSE:
+        b_z = tl.sum(b_s, axis=0)
+        b_o = -b_o + b_z[None] + b_s
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps)
+        for BS in BS_LIST
+        for num_warps in [2, 4, 8]
+    ],
+    key=["B", "H", "S", "BT", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_local_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = tl.load(chunk_indices + i_t * 2).to(tl.int32), tl.load(
+            chunk_indices + i_t * 2 + 1
+        ).to(tl.int32)
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if HEAD_FIRST:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h * T) * S,
+            (T, S),
+            (S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    else:
+        p_s = tl.make_block_ptr(
+            s + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+        p_o = tl.make_block_ptr(
+            o + (bos * H + i_h) * S,
+            (T, S),
+            (H * S, 1),
+            (i_t * BT, i_s * BS),
+            (BT, BS),
+            (1, 0),
+        )
+    # [BT, BS]
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    if REVERSE:
+        b_o = tl.cumsum(b_s, axis=0, reverse=True)
+    else:
+        b_o = tl.cumsum(b_s, axis=0)
+    if HAS_SCALE:
+        b_o *= scale
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": BT}, num_warps=num_warps, num_stages=num_stages)
+        for BT in [32, 64, 128, 256]
+        for num_warps in [2, 4, 8]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=["B", "H", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_global_cumsum_scalar_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_nh = tl.program_id(0)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    T = eos - bos
+
+    b_z = tl.zeros([], dtype=tl.float32)
+    NT = tl.cdiv(T, BT)
+    for i_c in range(NT):
+        i_t = NT - 1 - i_c if REVERSE else i_c
+        if HEAD_FIRST:
+            p_s = tl.make_block_ptr(
+                s + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+            )
+            p_o = tl.make_block_ptr(
+                o + bos * H + i_h * T, (T,), (1,), (i_t * BT,), (BT,), (0,)
+            )
+        else:
+            p_s = tl.make_block_ptr(
+                s + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+            p_o = tl.make_block_ptr(
+                o + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+            )
+        b_s = tl.load(p_s, boundary_check=(0,)).to(tl.float32)
+        b_o = tl.cumsum(b_s, axis=0)
+        b_ss = tl.sum(b_s, 0)
+        if REVERSE:
+            b_o = -b_o + b_ss + b_s
+        b_o += b_z
+        if i_c >= 0:
+            b_z += b_ss
+        if HAS_SCALE:
+            b_o *= scale
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {
+        "HAS_SCALE": lambda args: args["scale"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BT": BT}, num_warps=num_warps, num_stages=num_stages)
+        for BT in [16, 32, 64, 128]
+        for num_warps in [2, 4, 8]
+        for num_stages in [1, 2, 3, 4]
+    ],
+    key=["B", "H", "S", "IS_VARLEN", "REVERSE"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_global_cumsum_vector_kernel(
+    s,
+    o,
+    scale,
+    cu_seqlens,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    REVERSE: tl.constexpr,
+    HAS_SCALE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    HEAD_FIRST: tl.constexpr,
+):
+    i_s, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int32), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    T = eos - bos
+
+    b_z = tl.zeros([BS], dtype=tl.float32)
+    NT = tl.cdiv(T, BT)
+    for i_c in range(NT):
+        i_t = NT - 1 - i_c if REVERSE else i_c
+        if HEAD_FIRST:
+            p_s = tl.make_block_ptr(
+                s + (bos * H + i_h * T) * S,
+                (T, S),
+                (S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+            p_o = tl.make_block_ptr(
+                o + (bos * H + i_h * T) * S,
+                (T, S),
+                (S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+        else:
+            p_s = tl.make_block_ptr(
+                s + (bos * H + i_h) * S,
+                (T, S),
+                (H * S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+            p_o = tl.make_block_ptr(
+                o + (bos * H + i_h) * S,
+                (T, S),
+                (H * S, 1),
+                (i_t * BT, i_s * BS),
+                (BT, BS),
+                (1, 0),
+            )
+        # [BT, BS]
+        b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+        if REVERSE:
+            b_c = b_z[None, :] + tl.cumsum(b_s, axis=0, reverse=True)
+        else:
+            b_c = b_z[None, :] + tl.cumsum(b_s, axis=0)
+        if HAS_SCALE:
+            b_c *= scale
+        tl.store(p_o, b_c.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+        b_z += tl.sum(b_s, 0)
+
+
+def chunk_local_cumsum_scalar(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = g.shape
+    else:
+        B, T, H = g.shape
+    assert chunk_size == 2 ** (
+        chunk_size.bit_length() - 1
+    ), "chunk_size must be a power of 2"
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+    grid = (NT, B * H)
+    chunk_local_cumsum_scalar_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return g
+
+
+def chunk_local_cumsum_vector(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T, S = g.shape
+    else:
+        B, T, H, S = g.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    assert chunk_size == 2 ** (
+        chunk_size.bit_length() - 1
+    ), "chunk_size must be a power of 2"
+
+    g_org, g = g, torch.empty_like(g, dtype=output_dtype or g.dtype)
+
+    def grid(meta):
+        return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+
+    # keep cummulative normalizer in fp32
+    # this kernel is equivalent to
+    # g = g.view(B, H, NT, BT, -1).cumsum(-2).view(B, H, T, -1)
+    chunk_local_cumsum_vector_kernel[grid](
+        s=g_org,
+        o=g,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BT=BT,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return g
+
+
+@input_guard
+def chunk_global_cumsum_scalar(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T = s.shape
+    else:
+        B, T, H = s.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+
+    z = torch.empty_like(s, dtype=output_dtype or s.dtype)
+    grid = (N * H,)
+    chunk_global_cumsum_scalar_kernel[grid](
+        s=s,
+        o=z,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return z
+
+
+@input_guard
+def chunk_global_cumsum_vector(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if head_first:
+        B, H, T, S = s.shape
+    else:
+        B, T, H, S = s.shape
+    N = len(cu_seqlens) - 1 if cu_seqlens is not None else B
+    BS = min(32, triton.next_power_of_2(S))
+
+    z = torch.empty_like(s, dtype=output_dtype or s.dtype)
+    grid = (triton.cdiv(S, BS), N * H)
+    chunk_global_cumsum_vector_kernel[grid](
+        s=s,
+        o=z,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BS=BS,
+        HEAD_FIRST=head_first,
+        REVERSE=reverse,
+    )
+    return z
+
+
+@input_guard
+def chunk_global_cumsum(
+    s: torch.Tensor,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    scale: float = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert (
+            s.shape[0] == 1
+        ), "Only batch size 1 is supported when cu_seqlens are provided"
+    if len(s.shape) == 3:
+        return chunk_global_cumsum_scalar(
+            s=s,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    elif len(s.shape) == 4:
+        return chunk_global_cumsum_vector(
+            s=s,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            scale=scale,
+            head_first=head_first,
+            output_dtype=output_dtype,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported input shape {s.shape}, "
+            f"which should be [B, T, H]/[B, T, H, D] if `head_first=False` "
+            f"or [B, H, T]/[B, H, T, D] otherwise",
+        )
+
+
+@input_guard
+def chunk_local_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    reverse: bool = False,
+    scale: float = None,
+    cu_seqlens: torch.Tensor | None = None,
+    head_first: bool = False,
+    output_dtype: torch.dtype | None = torch.float,
+    chunk_indices: torch.LongTensor | None = None,
+    **kwargs,
+) -> torch.Tensor:
+    if cu_seqlens is not None:
+        assert (
+            g.shape[0] == 1
+        ), "Only batch size 1 is supported when cu_seqlens are provided"
+    if len(g.shape) == 3:
+        return chunk_local_cumsum_scalar(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+    elif len(g.shape) == 4:
+        return chunk_local_cumsum_vector(
+            g=g,
+            chunk_size=chunk_size,
+            reverse=reverse,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+            head_first=head_first,
+            output_dtype=output_dtype,
+            chunk_indices=chunk_indices,
+        )
+    else:
+        raise ValueError(
+            f"Unsupported input shape {g.shape}, "
+            f"which should be (B, T, H, D) if `head_first=False` "
+            f"or (B, H, T, D) otherwise",
+        )

--- a/src/flag_attn/gated_linear_attention/index.py
+++ b/src/flag_attn/gated_linear_attention/index.py
@@ -1,0 +1,63 @@
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+import torch
+import triton
+
+from .utils import tensor_cache
+
+
+@tensor_cache
+def prepare_lens(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    return cu_seqlens[1:] - cu_seqlens[:-1]
+
+
+@tensor_cache
+def prepare_chunk_indices(
+    cu_seqlens: torch.LongTensor,
+    chunk_size: int,
+    cu_seqlens_cpu: torch.LongTensor | None = None,
+) -> torch.LongTensor:
+    # The FlagGems GLA wrapper forwards this optional host mirror for API
+    # compatibility; index construction only needs the device tensor.
+    del cu_seqlens_cpu
+    chunk_counts = triton.cdiv(prepare_lens(cu_seqlens), chunk_size)
+    chunk_offsets = torch.cat([cu_seqlens.new_tensor([0]), chunk_counts]).cumsum(-1)
+    chunk_arange = torch.arange(chunk_offsets[-1], device=cu_seqlens.device)
+    seq_ids = torch.repeat_interleave(
+        torch.arange(chunk_counts.numel(), device=cu_seqlens.device),
+        chunk_counts,
+    )
+    chunk_ids = chunk_arange - torch.repeat_interleave(chunk_offsets[:-1], chunk_counts)
+    return torch.stack([seq_ids, chunk_ids], 1).to(cu_seqlens)
+
+
+@tensor_cache
+def prepare_chunk_offsets(
+    cu_seqlens: torch.LongTensor, chunk_size: int
+) -> torch.LongTensor:
+    return torch.cat(
+        [
+            cu_seqlens.new_tensor([0]),
+            triton.cdiv(prepare_lens(cu_seqlens), chunk_size),
+        ]
+    ).cumsum(-1)
+
+
+@tensor_cache
+def prepare_token_indices(cu_seqlens: torch.LongTensor) -> torch.LongTensor:
+    """Return a 2-D tensor ``[total_tokens, 2]`` with ``[seq_id, intra_seq_pos]``."""
+    lens = prepare_lens(cu_seqlens)
+    total = lens.sum().item()
+    seq_ids = torch.arange(
+        lens.numel(), device=cu_seqlens.device, dtype=torch.long
+    ).repeat_interleave(lens)
+    offsets = torch.zeros(lens.numel(), device=cu_seqlens.device, dtype=torch.long)
+    offsets[1:] = lens.cumsum(0)[:-1]
+    intra = (
+        torch.arange(total, device=cu_seqlens.device, dtype=torch.long)
+        - offsets[seq_ids]
+    )
+    return torch.stack([seq_ids, intra], 1)

--- a/src/flag_attn/gated_linear_attention/utils.py
+++ b/src/flag_attn/gated_linear_attention/utils.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+# For a list of all contributors, visit:
+#   https://github.com/fla-org/flash-linear-attention/graphs/contributors
+
+"""Runtime-independent helpers for the vendored GLA kernels."""
+
+import contextlib
+import functools
+from collections.abc import Callable
+from typing import Any
+
+import torch
+
+
+def tensor_cache(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
+    """Cache the eight most recent calls by tensor identity."""
+    cache_entries: list[tuple[tuple, dict, Any]] = []
+    cache_size = 8
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        nonlocal cache_entries
+        for index, (last_args, last_kwargs, last_result) in enumerate(cache_entries):
+            if (
+                len(args) == len(last_args)
+                and len(kwargs) == len(last_kwargs)
+                and all(arg is last_arg for arg, last_arg in zip(args, last_args))
+                and all(
+                    key in last_kwargs and value is last_kwargs[key]
+                    for key, value in kwargs.items()
+                )
+            ):
+                cache_entries = (
+                    cache_entries[:index]
+                    + cache_entries[index + 1 :]
+                    + [(args, kwargs, last_result)]
+                )
+                return last_result
+
+        result = fn(*args, **kwargs)
+        if len(cache_entries) >= cache_size:
+            cache_entries = cache_entries[1:]
+        cache_entries.append((args, kwargs, result))
+        return result
+
+    return wrapper
+
+
+def input_guard(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Make tensor inputs contiguous and select their CUDA device."""
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        contiguous_args = tuple(
+            value.contiguous() if isinstance(value, torch.Tensor) else value
+            for value in args
+        )
+        contiguous_kwargs = {
+            key: value.contiguous() if isinstance(value, torch.Tensor) else value
+            for key, value in kwargs.items()
+        }
+
+        tensor = next(
+            (
+                value
+                for value in (*args, *kwargs.values())
+                if isinstance(value, torch.Tensor)
+            ),
+            None,
+        )
+        context = (
+            torch.cuda.device(tensor.device)
+            if tensor is not None and tensor.is_cuda
+            else contextlib.nullcontext()
+        )
+        with context:
+            return fn(*contiguous_args, **contiguous_kwargs)
+
+    return wrapper
+
+
+def check_shared_mem(arch: str = "none", tensor_idx: int = 0) -> bool:
+    """Return whether the active CUDA device supports the larger GLA tiles."""
+    del arch, tensor_idx
+    if not torch.cuda.is_available():
+        return False
+    try:
+        properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    except (AssertionError, RuntimeError):
+        return False
+
+    # PR #43 fixed the primary PyTorch property name. The remaining names keep
+    # compatibility with alternative runtimes and older device wrappers.
+    for name in (
+        "shared_memory_per_multiprocessor",
+        "max_shared_mem",
+        "max_shared_memory_per_multiprocessor",
+        "max_shared_memory",
+    ):
+        max_shared = getattr(properties, name, None)
+        if max_shared is not None:
+            return max_shared >= 166_000
+    return False

--- a/src/flag_attn/minimax_sparse_attention/__init__.py
+++ b/src/flag_attn/minimax_sparse_attention/__init__.py
@@ -1,6 +1,21 @@
-"""Triton H100 v0 — Paged KV Cache version.
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-Uses vLLM's paged KV cache format:
+"""MiniMax M3 Sparse Attention with a paged KV cache.
+
+The cache layout is compatible with vLLM:
   kv_cache: [num_blocks, num_kv_heads, 128, 2*head_dim]  K=[..., :head_dim] V=[..., head_dim:]
   index_kv_cache: [num_blocks, 128, head_dim]
   block_table: [batch, max_blocks]

--- a/src/flag_attn/minimax_sparse_attention/__init__.py
+++ b/src/flag_attn/minimax_sparse_attention/__init__.py
@@ -1,21 +1,6 @@
-# Copyright 2026 FlagOS Contributors
-# Copyright contributors to the vLLM project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+"""Triton H100 v0 — Paged KV Cache version.
 
-"""MiniMax M3 Sparse Attention with a paged KV cache.
-
-The cache layout is compatible with vLLM:
+Uses vLLM's paged KV cache format:
   kv_cache: [num_blocks, num_kv_heads, 128, 2*head_dim]  K=[..., :head_dim] V=[..., head_dim:]
   index_kv_cache: [num_blocks, 128, head_dim]
   block_table: [batch, max_blocks]

--- a/src/flag_attn/minimax_sparse_attention/__init__.py
+++ b/src/flag_attn/minimax_sparse_attention/__init__.py
@@ -1,0 +1,41 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MiniMax M3 Sparse Attention with a paged KV cache.
+
+The cache layout is compatible with vLLM:
+  kv_cache: [num_blocks, num_kv_heads, 128, 2*head_dim]  K=[..., :head_dim] V=[..., head_dim:]
+  index_kv_cache: [num_blocks, 128, head_dim]
+  block_table: [batch, max_blocks]
+"""
+
+from .index_topk import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_index_decode,
+    minimax_m3_index_decode_score,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+)
+from .sparse_attn import minimax_m3_sparse_attn, minimax_m3_sparse_attn_decode
+
+__all__ = [
+    "SPARSE_BLOCK_SIZE",
+    "minimax_m3_index_decode",
+    "minimax_m3_index_decode_score",
+    "minimax_m3_index_score",
+    "minimax_m3_index_topk",
+    "minimax_m3_sparse_attn",
+    "minimax_m3_sparse_attn_decode",
+]

--- a/src/flag_attn/minimax_sparse_attention/index_topk.py
+++ b/src/flag_attn/minimax_sparse_attention/index_topk.py
@@ -1,0 +1,997 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for MiniMax M3 lightning-indexer block scoring + top-k.
+
+Index queries score each 128-token block of index keys (max over the block),
+then the top-k blocks (plus forced init/local blocks) are selected per query
+token. Adapted to vLLM's paged KV cache: the KV page size is forced to equal the
+sparse block size (128), so one sparse block maps to exactly one page.
+
+Index-K cache layout (vLLM): ``(num_blocks, 128, idx_head_dim)`` (single head).
+
+Only the paths MiniMax M3 uses are implemented: score_type="max", index value
+disabled (score-only indexer), single shared index head. The selected block ids
+feed the block-sparse attention kernels in ``sparse_attn``.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import current_platform, round_up
+
+# One sparse block == one KV page.
+SPARSE_BLOCK_SIZE = 128
+
+
+# ---------------------------------------------------------------------------
+# Bitonic top-k helpers (layout-agnostic).
+# ---------------------------------------------------------------------------
+@triton.jit
+def _compare_and_swap(x, ids, flip, i: tl.constexpr, n_dims: tl.constexpr):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    shape: tl.constexpr = [n_outer * 2**i, 2, 2 ** (n_dims - i - 1)]
+    y = tl.reshape(x, shape)
+    mask = tl.arange(0, 2)[None, :, None]
+    left = tl.broadcast_to(tl.sum(y * (1 - mask), 1)[:, None, :], shape).to(y.dtype)
+    right = tl.broadcast_to(tl.sum(y * mask, 1)[:, None, :], shape).to(y.dtype)
+    left = tl.reshape(left, x.shape)
+    right = tl.reshape(right, x.shape)
+    y_idx = tl.reshape(ids, shape)
+    left_idx = tl.broadcast_to(tl.sum(y_idx * (1 - mask), 1)[:, None, :], shape)
+    right_idx = tl.broadcast_to(tl.sum(y_idx * mask, 1)[:, None, :], shape)
+    left_idx = tl.reshape(left_idx, x.shape).to(y_idx.dtype)
+    right_idx = tl.reshape(right_idx, x.shape).to(y_idx.dtype)
+    idtype = tl.core.get_int_dtype(bitwidth=x.dtype.primitive_bitwidth, signed=True)
+    ileft = left.to(idtype, bitcast=True)
+    iright = right.to(idtype, bitcast=True)
+    ix = x.to(idtype, bitcast=True)
+    cond = (left > right) != flip
+    ret = ix ^ tl.where(cond, ileft ^ iright, tl.zeros_like(ix))
+    new_ids = ids ^ tl.where(cond, left_idx ^ right_idx, tl.zeros_like(ids))
+    return ret.to(x.dtype, bitcast=True), new_ids
+
+
+@triton.jit
+def _bitonic_merge(
+    x, ids, stage: tl.constexpr, order: tl.constexpr, n_dims: tl.constexpr
+):
+    n_outer: tl.constexpr = x.numel >> n_dims
+    tl.static_assert(stage <= n_dims)
+    if order == 2:
+        shape: tl.constexpr = [n_outer * 2 ** (n_dims - 1 - stage), 2, 2**stage]
+        flip = tl.reshape(
+            tl.broadcast_to(tl.arange(0, 2)[None, :, None], shape), x.shape
+        )
+    else:
+        flip = order
+    for i in tl.static_range(stage):
+        x, ids = _compare_and_swap(x, ids, flip, i + (n_dims - stage), n_dims)
+    return x, ids
+
+
+# ---------------------------------------------------------------------------
+# Index block-score kernel (paged). score[h, token, block] = max over the
+# 128-token block of (idx_q . index_k), causal-masked. BLOCK_SIZE_K == 128 so
+# each K-tile is exactly one page (BLOCKS_PER_K_BLOCK == 1).
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _index_block_score_kernel(
+    q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
+    ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
+    score_ptr,  # [num_idx_heads, total_q, max_block]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens,  # [batch+1] query start offsets
+    seq_lens,  # [batch] total K length
+    prefix_lens,  # [batch] context length before this chunk's queries
+    num_idx_heads,
+    head_dim: tl.constexpr,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_ik_blk,
+    stride_ik_pos,
+    stride_ik_d,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+):
+    pid_q = tl.program_id(0)
+    pid_bh = tl.program_id(1)
+    pid_b = pid_bh // num_idx_heads
+    pid_h = pid_bh % num_idx_heads
+
+    seq_start = tl.load(cu_seqlens + pid_b)
+    q_len = tl.load(cu_seqlens + pid_b + 1) - seq_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if BLOCK_SIZE_Q * pid_q >= q_len:
+        return
+
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + seq_start * stride_q_n + pid_h * stride_q_h,
+        shape=(q_len, head_dim),
+        strides=(stride_q_n, stride_q_d),
+        offsets=(pid_q * BLOCK_SIZE_Q, 0),
+        block_shape=(BLOCK_SIZE_Q, head_dim),
+        order=(1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0,), padding_option="zero")
+    q_start = prefix_len + pid_q * BLOCK_SIZE_Q
+
+    off_q = tl.arange(0, BLOCK_SIZE_Q) + pid_q * BLOCK_SIZE_Q + prefix_len
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, head_dim)
+    # Block table row for this request.
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    # Causal window: only blocks up to the last query token's position.
+    hi = min(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
+    for i in tl.range(0, hi, BLOCK_SIZE_K):
+        blk = i // BLOCK_SIZE_K
+        page = tl.load(bt_row + blk).to(tl.int64)
+        pos = i + off_k
+        # index-K for this page: [BLOCK_SIZE_D, BLOCK_SIZE_K] (transposed)
+        # we don't need masked load for K, because KV cache ensures
+        # allocation is multiple of BLOCK_SIZE_K.
+        # for tokens beyond seqlen, they will be masked in qk later.
+        k = tl.load(
+            ik_cache_ptr
+            + page * stride_ik_blk
+            + off_k[None, :] * stride_ik_pos
+            + off_d[:, None] * stride_ik_d,
+        )
+        qk = tl.dot(q, k)
+        # apply causal mask as needed
+        if q_start < i + BLOCK_SIZE_K:
+            qk = tl.where(off_q[:, None] >= pos[None, :], qk, float("-inf"))
+        # one sparse block per K-tile -> max over the 128 positions
+        score = tl.max(qk, axis=1)  # [BLOCK_SIZE_Q]
+        s_ptrs = (
+            score_ptr
+            + pid_h * stride_s_h
+            + (seq_start + pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q))
+            * stride_s_n
+            + blk * stride_s_k
+        )
+        q_store_mask = (pid_q * BLOCK_SIZE_Q + tl.arange(0, BLOCK_SIZE_Q)) < q_len
+        tl.store(s_ptrs, score, mask=q_store_mask)
+
+
+# ---------------------------------------------------------------------------
+# Top-k selection over per-token block scores (layout-agnostic). block_size_q
+# is 1 for M3, so top-k is computed per query token.
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE_K": 2048}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 1024}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 512}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=2, num_stages=2),
+    ],
+    key=["BLOCK_SIZE_T"],
+)
+@triton.jit(do_not_specialize_on_alignment=["prefix_lens"])
+def _topk_index_kernel(
+    s_ptr,  # [num_heads, total_q, max_block]
+    ti_ptr,  # [num_heads, total_q, topk]
+    sample_interval: tl.constexpr,  # block_size_q (1 for M3)
+    block_size: tl.constexpr,  # sparse block size (128)
+    cu_seqlens,
+    cu_seqblocks_q,
+    prefix_lens,
+    topk,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_ti_h,
+    stride_ti_n,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    tl.static_assert(BLOCK_SIZE_K > BLOCK_SIZE_T)
+    pid_q = tl.program_id(0)
+    pid_b = tl.program_id(1)
+    pid_h = tl.program_id(2)
+    seq_start = tl.load(cu_seqlens + pid_b)
+    block_start = tl.load(cu_seqblocks_q + pid_b)
+    block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q >= block_num:
+        return
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    s_ptrs = (
+        s_ptr
+        + (seq_start + pid_q * sample_interval) * stride_s_n
+        + pid_h * stride_s_h
+        + off_k * stride_s_k
+    )
+    topk_score = tl.full((BLOCK_SIZE_K,), -1e30, dtype=tl.float32)
+    topk_idx = tl.full((BLOCK_SIZE_K,), 0, dtype=tl.int32)
+    left_half_mask = tl.arange(0, BLOCK_SIZE_K) < BLOCK_SIZE_K // 2
+    valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+    for i in tl.range(0, valid_blocks, BLOCK_SIZE_K):
+        causal_mask = i + off_k < valid_blocks
+        local_mask = i + off_k >= max(0, valid_blocks - local_blocks)
+        init_mask = i + off_k < init_blocks
+        score = tl.load(s_ptrs, mask=causal_mask, other=-1e30).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        s_ptrs = s_ptrs + stride_s_k * BLOCK_SIZE_K
+        if MASK_INIT:
+            score = tl.where(causal_mask & init_mask, score - 1e29, score)
+        else:
+            score = tl.where(causal_mask & init_mask, 1e30, score)
+        if MASK_LOCAL:
+            score = tl.where(causal_mask & local_mask, score - 1e28, score)
+        else:
+            score = tl.where(causal_mask & local_mask, 1e29, score)
+        topk_score, last_topk_score = score, topk_score
+        topk_idx, last_topk_idx = (tl.where(causal_mask, i + off_k + 1, 0), topk_idx)
+        n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+        for j in tl.static_range(1, n_dims):
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), j, 2, n_dims
+            )
+        if i != 0:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, False, n_dims
+            )
+            topk_score_new = last_topk_score * left_half_mask + topk_score * (
+                1 - left_half_mask
+            )
+            topk_idx_new = last_topk_idx * left_half_mask + topk_idx * (
+                1 - left_half_mask
+            )
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score_new, topk_idx_new.to(tl.int32), n_dims, True, n_dims
+            )
+        else:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, True, n_dims
+            )
+    topk_mask = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    topk_idx = tl.sum(
+        topk_mask[:, None]
+        * tl.reshape(topk_idx - 1, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+    ti_ptrs = (
+        ti_ptr
+        + (block_start + pid_q) * stride_ti_n
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+    store_mask = off_t < topk
+    valid_mask = off_t < valid_blocks
+    topk_idx = tl.where(store_mask & valid_mask, topk_idx, -1)
+    tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty), mask=store_mask)
+
+
+# ---------------------------------------------------------------------------
+# Decode index-score kernel (split-K over seq blocks). Decode batches are
+# flattened request-major, with a runtime query length used to map each query
+# token back to its request metadata. Chunk counts depend only on shape
+# constants so the grid is fixed within a cuda graph. The score scale is omitted
+# because decode only consumes block ordering.
+# ---------------------------------------------------------------------------
+@triton.jit(do_not_specialize=["num_kv_chunks", "decode_query_len"])
+def _decode_index_score_kernel(
+    q_ptr,  # idx_q: [total_q, num_idx_heads, head_dim]
+    ik_cache_ptr,  # index-K cache: [num_blocks, 128, head_dim]
+    score_ptr,  # [num_idx_heads, total_q, max_block]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    seq_lens,  # [num_reqs]
+    num_idx_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    init_blocks,
+    local_blocks,
+    decode_query_len,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_ik_blk,
+    stride_ik_pos,
+    stride_ik_d,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_bt_b,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    BLOCK_SIZE_Q: tl.constexpr,
+    num_kv_chunks,
+    USE_PDL: tl.constexpr,
+):
+    BLOCK_SIZE_HQ: tl.constexpr = num_idx_heads * BLOCK_SIZE_Q
+    pid_r = tl.program_id(0)
+    pid_c = tl.program_id(1)
+    hq_offsets = tl.arange(0, BLOCK_SIZE_HQ)
+    h_offsets = hq_offsets // BLOCK_SIZE_Q
+    q_offsets = hq_offsets % BLOCK_SIZE_Q
+    q_mask = q_offsets < decode_query_len
+    q_ids = pid_r * decode_query_len + q_offsets
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + pid_r)
+    query_pos = seq_len - decode_query_len + q_offsets
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks_q = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+    kv_len_max = tl.max(tl.where(q_mask, kv_len, 0), axis=0)
+    num_blocks = (kv_len_max + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+
+    # block-aligned fixed-count split: grid independent of seq_len (cuda graph).
+    chunk_size_blocks = (num_blocks + num_kv_chunks - 1) // num_kv_chunks
+    chunk_start_block = pid_c * chunk_size_blocks
+    chunk_end_block = tl.minimum(chunk_start_block + chunk_size_blocks, num_blocks)
+    if chunk_start_block >= chunk_end_block:
+        return
+    off_k = tl.arange(0, BLOCK_SIZE_K)  # positions within a 128-block
+    off_d = tl.arange(0, head_dim)
+    bt_row = block_table_ptr + pid_r * stride_bt_b
+    # Force-select init (1e30) and local (1e29, higher priority) blocks.
+    local_start = tl.maximum(0, num_blocks_q - local_blocks)
+    # Query vectors for all index heads in a small spec-decode block.
+    q = tl.load(
+        q_ptr
+        + q_ids[None, :] * stride_q_n
+        + h_offsets[None, :] * stride_q_h
+        + off_d[:, None] * stride_q_d,
+        mask=q_mask[None, :],
+        other=0.0,
+    )  # [D,HQ]
+    for blk in tl.range(chunk_start_block, chunk_end_block):
+        page = tl.load(bt_row + blk).to(tl.int64)
+        pos = blk * BLOCK_SIZE_K + off_k
+        pos_mask = pos[:, None] < kv_len[None, :]
+        # we don't need masked load for K, because KV cache ensures
+        # allocation is multiple of BLOCK_SIZE_K.
+        # for tokens beyond seqlen, they will be masked in qk later.
+        k = tl.load(
+            ik_cache_ptr
+            + page * stride_ik_blk
+            + off_k[:, None] * stride_ik_pos
+            + off_d * stride_ik_d,
+        )  # [N,D]
+        # fp32 accumulation is required for the fp8 (e4m3) index cache: q/k are
+        # loaded in their stored dtype (bf16 or e4m3) and the MMA accumulates in
+        # fp32 so the per-block max score is exact for the fp8 indexer too.
+        kq = tl.dot(k, q, out_dtype=tl.float32)  # [N,HQ]
+        kq = tl.where(pos_mask & q_mask[None, :], kq, float("-inf"))
+        score = tl.max(kq, axis=0)  # [HQ]
+        is_visible_block = blk < num_blocks_q
+        is_init = (blk < init_blocks) & is_visible_block
+        is_local = (blk >= local_start) & is_visible_block
+        score = tl.where(is_local, 1e29, tl.where(is_init, 1e30, score))
+        tl.store(
+            score_ptr + h_offsets * stride_s_h + q_ids * stride_s_n + blk * stride_s_k,
+            score,
+            mask=q_mask,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Decode top-k (split-K): per-chunk partial top-k + merge. Forced init/local
+# blocks are already encoded in the scores.
+# ---------------------------------------------------------------------------
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=8, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 256}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK_SIZE_K": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK_SIZE_K": 64}, num_warps=2, num_stages=2),
+    ],
+    key=["topk"],
+)
+@triton.jit(do_not_specialize=["chunk_blocks", "decode_query_len"])
+def _topk_index_partial_kernel(
+    s_ptr,  # score: [num_idx_heads, total_q, max_block]
+    ts_partial_ptr,  # partial scores out: [NUM_TOPK_CHUNKS, num_idx_heads, total_q, T]
+    ti_partial_ptr,  # partial idx out (1-indexed global, 0=invalid): same shape
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,  # sparse block size (128)
+    topk: tl.constexpr,
+    chunk_blocks,  # how many score-blocks each chunk owns
+    decode_query_len,
+    stride_s_h,
+    stride_s_b,
+    stride_s_k,
+    stride_ts_c,
+    stride_ts_h,
+    stride_ts_b,
+    stride_ts_t,
+    stride_ti_c,
+    stride_ti_h,
+    stride_ti_b,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    tl.static_assert(topk < BLOCK_SIZE_K)
+    pid_b = tl.program_id(0)  # flattened query-token id
+    pid_h = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    # Slice this chunk owns within [0, num_blocks).
+    chunk_start = pid_chunk * chunk_blocks
+    chunk_end = tl.minimum(chunk_start + chunk_blocks, num_blocks)
+    chunk_actual = tl.maximum(chunk_end - chunk_start, 0)
+
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+
+    s_ptrs = (
+        s_ptr
+        + pid_b * stride_s_b
+        + pid_h * stride_s_h
+        + (chunk_start + off_k) * stride_s_k
+    )
+
+    topk_score = tl.full((BLOCK_SIZE_K,), -1e30, dtype=tl.float32)
+    topk_idx = tl.full((BLOCK_SIZE_K,), 0, dtype=tl.int32)
+    left_half_mask = tl.arange(0, BLOCK_SIZE_K) < BLOCK_SIZE_K // 2
+
+    # Streaming top-K within this chunk. tl.range(0, 0) is a no-op so empty
+    # chunks (chunk_actual == 0) skip the body and store sentinel -1e30 / 0.
+    for i in tl.range(0, chunk_actual, BLOCK_SIZE_K):
+        mask = off_k < chunk_actual - i
+        score = tl.load(s_ptrs, mask=mask, other=-1e30).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        s_ptrs = s_ptrs + stride_s_k * BLOCK_SIZE_K
+        topk_score, last_topk_score = score, topk_score
+        topk_idx, last_topk_idx = (
+            tl.where(mask, chunk_start + i + off_k + 1, 0),  # 1-indexed global
+            topk_idx,
+        )
+        n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+        for j in tl.static_range(1, n_dims):
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), j, 2, n_dims
+            )
+        if i != 0:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, False, n_dims
+            )
+            topk_score_new = last_topk_score * left_half_mask + topk_score * (
+                1 - left_half_mask
+            )
+            topk_idx_new = last_topk_idx * left_half_mask + topk_idx * (
+                1 - left_half_mask
+            )
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score_new, topk_idx_new.to(tl.int32), n_dims, True, n_dims
+            )
+        else:
+            topk_score, topk_idx = _bitonic_merge(
+                topk_score, topk_idx.to(tl.int32), n_dims, True, n_dims
+            )
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Extract first BLOCK_SIZE_T entries (top-K of this chunk after the sort).
+    topk_mask_extract = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    final_score = tl.sum(
+        topk_mask_extract[:, None]
+        * tl.reshape(topk_score, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+    final_idx = tl.sum(
+        topk_mask_extract[:, None]
+        * tl.reshape(topk_idx, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+
+    # Always write all BLOCK_SIZE_T slots — invalid slots carry -1e30 / 0
+    # sentinels and lose to real scores in the merge stage.
+    ts_ptrs = (
+        ts_partial_ptr
+        + pid_chunk * stride_ts_c
+        + pid_b * stride_ts_b
+        + pid_h * stride_ts_h
+        + off_t * stride_ts_t
+    )
+    ti_ptrs = (
+        ti_partial_ptr
+        + pid_chunk * stride_ti_c
+        + pid_b * stride_ti_b
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+    tl.store(ts_ptrs, final_score)
+    tl.store(ti_ptrs, final_idx)
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"]),
+        "BLOCK_SIZE_K": lambda args: triton.next_power_of_2(
+            args["num_topk_chunks"] * triton.next_power_of_2(args["topk"])
+        ),
+    }
+)
+@triton.jit(do_not_specialize=["num_topk_chunks", "decode_query_len"])
+def _topk_index_merge_kernel(
+    ts_partial_ptr,  # partial scores: [NUM_TOPK_CHUNKS, num_idx_heads, total_q, T]
+    ti_partial_ptr,  # partial idx (1-indexed global, 0=invalid): same shape
+    ti_final_ptr,  # final idx (0-indexed, -1=invalid): [num_idx_heads, total_q, topk]
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,  # sparse block size (128)
+    topk: tl.constexpr,
+    decode_query_len,
+    stride_ts_c,
+    stride_ts_h,
+    stride_ts_b,
+    stride_ts_t,
+    stride_ti_c,
+    stride_ti_h,
+    stride_ti_b,
+    stride_ti_t,
+    stride_tif_h,
+    stride_tif_b,
+    stride_tif_t,
+    num_topk_chunks,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    pid_b = tl.program_id(0)  # flattened query-token id
+    pid_h = tl.program_id(1)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    # Load NUM_TOPK_CHUNKS * BLOCK_SIZE_T candidates, padded to BLOCK_SIZE_K.
+    # Candidate at flat position p comes from chunk = p // BLOCK_SIZE_T,
+    # in_chunk = p % BLOCK_SIZE_T.
+    off = tl.arange(0, BLOCK_SIZE_K)
+    chunk_idx = off // BLOCK_SIZE_T
+    in_chunk_idx = off % BLOCK_SIZE_T
+    valid = chunk_idx < num_topk_chunks
+
+    score_offset = (
+        chunk_idx * stride_ts_c
+        + pid_h * stride_ts_h
+        + pid_b * stride_ts_b
+        + in_chunk_idx * stride_ts_t
+    )
+    idx_offset = (
+        chunk_idx * stride_ti_c
+        + pid_h * stride_ti_h
+        + pid_b * stride_ti_b
+        + in_chunk_idx * stride_ti_t
+    )
+
+    score = tl.load(ts_partial_ptr + score_offset, mask=valid, other=-1e30).to(
+        tl.float32
+    )
+    score = tl.where(score != score, -1e30, score)
+    idx = tl.load(ti_partial_ptr + idx_offset, mask=valid, other=0).to(tl.int32)
+
+    # Full bitonic descending sort of BLOCK_SIZE_K items.
+    n_dims: tl.constexpr = tl.standard._log2(BLOCK_SIZE_K)
+    for j in tl.static_range(1, n_dims):
+        score, idx = _bitonic_merge(score, idx.to(tl.int32), j, 2, n_dims)
+    score, idx = _bitonic_merge(score, idx.to(tl.int32), n_dims, True, n_dims)
+
+    # Extract first BLOCK_SIZE_T positions — these are the global top-K.
+    extract_mask = tl.arange(0, BLOCK_SIZE_K // BLOCK_SIZE_T) == 0
+    topk_idx_final = tl.sum(
+        extract_mask[:, None]
+        * tl.reshape(idx - 1, [BLOCK_SIZE_K // BLOCK_SIZE_T, BLOCK_SIZE_T]),
+        axis=0,
+    )
+
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    tif_ptrs = (
+        ti_final_ptr
+        + pid_h * stride_tif_h
+        + pid_b * stride_tif_b
+        + off_t * stride_tif_t
+    )
+    store_mask = off_t < topk
+    topk_idx_final = tl.where(off_t < tl.minimum(topk, num_blocks), topk_idx_final, -1)
+    tl.store(
+        tif_ptrs, topk_idx_final.to(ti_final_ptr.dtype.element_ty), mask=store_mask
+    )
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers
+# ---------------------------------------------------------------------------
+@torch.no_grad()
+def minimax_m3_index_score(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [batch, max_blocks]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    seq_lens: torch.Tensor,  # [batch] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    max_seq_len: int,
+    num_kv_heads: int,
+) -> torch.Tensor:
+    """Compute per-token index scores for each visible sparse block.
+
+    Returns score [num_kv_heads, total_q, max_block], where each score is the
+    max over a 128-token index-K block. M3 has num_idx_heads == num_kv_heads.
+    """
+    total_q, num_idx_heads, head_dim = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    batch = cu_seqlens_q.shape[0] - 1
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+
+    # Keep score strides 16-divisible to avoid Triton recompiles.
+    score_block_stride = round_up(max_block, 16)
+    score = torch.empty(
+        (num_idx_heads, total_q, score_block_stride),
+        dtype=torch.float32,
+        device=idx_q.device,
+    )
+    BLOCK_SIZE_Q = 64
+    grid_score = (triton.cdiv(max_query_len, BLOCK_SIZE_Q), batch * num_idx_heads)
+    _index_block_score_kernel[grid_score](
+        idx_q,
+        index_kv_cache,
+        score,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        prefix_lens,
+        num_idx_heads,
+        head_dim,
+        idx_q.stride(0),
+        idx_q.stride(1),
+        idx_q.stride(2),
+        index_kv_cache.stride(0),
+        index_kv_cache.stride(1),
+        index_kv_cache.stride(2),
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+    )
+    return score
+
+
+@torch.no_grad()
+def minimax_m3_index_topk(
+    score: torch.Tensor,  # [num_idx_heads, total_q, max_block]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Select index top-k from a precomputed score tensor.
+
+    When ``out`` is provided (a ``[num_idx_heads, >=total_q, topk]`` buffer), the
+    result is written into ``out[:, :total_q, :]`` instead of a fresh tensor --
+    used to keep the top-k output at a stable address for cudagraph capture.
+    """
+    num_idx_heads = score.shape[0]
+    batch = cu_seqlens_q.shape[0] - 1
+    total_q = score.shape[1]
+    if out is not None:
+        topk_idx = out[:, :total_q, :]
+    else:
+        topk_idx = torch.empty(
+            (num_idx_heads, total_q, topk),
+            dtype=torch.int32,
+            device=score.device,
+        )
+    # block_size_q == 1 -> query blocks coincide with query tokens.
+    grid_topk = (max_query_len, batch, num_idx_heads)
+    _topk_index_kernel[grid_topk](
+        score,
+        topk_idx,
+        1,  # sample_interval (block_size_q)
+        SPARSE_BLOCK_SIZE,
+        cu_seqlens_q,
+        cu_seqlens_q,  # cu_seqblocks_q == cu_seqlens_q when block_size_q == 1
+        prefix_lens,
+        topk,
+        init_blocks,
+        local_blocks,
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        MASK_INIT=False,
+        MASK_LOCAL=False,
+    )
+    return topk_idx
+
+
+@torch.no_grad()
+def minimax_m3_index_decode_score(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    max_seq_len: int,
+    init_blocks: int,
+    local_blocks: int,
+    num_kv_heads: int,
+    decode_query_len: int,
+    max_decode_query_len: int,
+    score_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Decode index block-score (split-K, cudagraph-safe); no top-k.
+
+    Returns score [num_kv_heads, total_q, >=max_block] (fp32; init/local blocks
+    forced to 1e30/1e29). When ``score_out`` is given the scores are written into
+    it (read/written by strides, so a transposed view of a unified buffer is
+    accepted) instead of a fresh tensor -- used to share a unified score buffer
+    with the prefill side and run a single top-k over both.
+    """
+    total_q, num_idx_heads, head_dim = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    assert decode_query_len <= max_decode_query_len
+    assert total_q == seq_lens.shape[0] * decode_query_len
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+    use_pdl = current_platform.is_arch_support_pdl()
+    # `launch_pdl` is a Triton runtime kwarg only some backends accept (CUDA
+    # SM9+); this ROCm Triton rejects it even when False ("Keyword argument
+    # launch_pdl was specified but unrecognised"). Only pass it when PDL is
+    # actually supported -- on ROCm use_pdl is always False, so it's omitted.
+    pdl_kwargs: dict[str, bool | int] = {}
+    if use_pdl:
+        pdl_kwargs.update({"launch_pdl": True})
+    # TP=1 spec decode scores a wide 4-head x 4-position query tile per K block;
+    # reduce stages to ease memory/register pressure. Keep no-spec and TP=4
+    # single-head codegen unchanged.
+    score_kwargs = pdl_kwargs.copy()
+    if num_idx_heads > 1 and max_decode_query_len > 1:
+        score_kwargs.update({"num_warps": 4, "num_stages": 2})
+
+    if score_out is not None:
+        score = score_out
+    else:
+        # Keep score strides 16-divisible to avoid Triton recompiles.
+        score_block_stride = round_up(max_block, 16)
+        score = torch.empty(
+            (num_idx_heads, total_q, score_block_stride),
+            dtype=torch.float32,
+            device=idx_q.device,
+        )
+    # split-K over seq blocks; chunk count depends only on shape constants so
+    # the grid is fixed within a cuda graph.
+    TARGET_GRID = 512
+    MAX_NUM_KV_CHUNKS = 256
+    # Use the configured max decode length to avoid Triton recompiles when
+    # switching between qlen=1 and spec-decode verification batches.
+    BLOCK_SIZE_Q = triton.next_power_of_2(max_decode_query_len)
+    score_ctas_per_chunk = seq_lens.shape[0]
+    target = max(
+        1,
+        min(MAX_NUM_KV_CHUNKS, TARGET_GRID // max(1, score_ctas_per_chunk)),
+    )
+    num_kv_chunks = 1 << (target.bit_length() - 1)
+    grid_score = (seq_lens.shape[0], num_kv_chunks)
+    _decode_index_score_kernel[grid_score](
+        idx_q,
+        index_kv_cache,
+        score,
+        block_table,
+        seq_lens,
+        num_idx_heads,
+        head_dim,
+        init_blocks,
+        local_blocks,
+        decode_query_len,
+        idx_q.stride(0),
+        idx_q.stride(1),
+        idx_q.stride(2),
+        index_kv_cache.stride(0),
+        index_kv_cache.stride(1),
+        index_kv_cache.stride(2),
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        BLOCK_SIZE_Q=BLOCK_SIZE_Q,
+        num_kv_chunks=num_kv_chunks,
+        USE_PDL=use_pdl,
+        **score_kwargs,
+    )
+    return score
+
+
+@torch.no_grad()
+def minimax_m3_index_decode(
+    idx_q: torch.Tensor,  # [total_q, num_idx_heads, head_dim]
+    index_kv_cache: torch.Tensor,  # [num_blocks, 128, head_dim]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    max_seq_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    num_kv_heads: int,
+    decode_query_len: int,
+    max_decode_query_len: int,
+    out: torch.Tensor | None = None,
+    score_out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Decode index block-score + top-k, both split-K (cudagraph-safe).
+
+    Returns topk_idx [num_kv_heads, total_q, topk] (0-indexed block ids, -1 pad).
+    When ``out`` ([num_kv_heads, >=total_q, topk]) is given, writes into
+    ``out[:, :total_q, :]`` (stable address for cudagraph) instead of allocating.
+    When ``score_out`` ([num_kv_heads, total_q, >=max_block]) is given, the block
+    scores are written into it (read back by the top-k) instead of a fresh
+    tensor -- used to share a unified score buffer with the prefill side. Reads
+    via strides, so a transposed view of a block-major buffer is accepted.
+    """
+    total_q, num_idx_heads, _ = idx_q.shape
+    batch = total_q
+    max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
+    use_pdl = current_platform.is_arch_support_pdl()
+    pdl_kwargs: dict[str, bool | int] = {}
+    if use_pdl:
+        pdl_kwargs.update({"launch_pdl": True})
+    score = minimax_m3_index_decode_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        seq_lens,
+        max_seq_len,
+        init_blocks,
+        local_blocks,
+        num_kv_heads,
+        decode_query_len,
+        max_decode_query_len,
+        score_out=score_out,
+    )
+
+    if out is not None:
+        topk_idx = out[:, :total_q, :]
+    else:
+        topk_idx = torch.empty(
+            (num_idx_heads, total_q, topk),
+            dtype=torch.int32,
+            device=idx_q.device,
+        )
+    # Chunk count is shape-constant (cudagraph-safe), capped so the merge sorts
+    # pow2(num_topk_chunks * pow2(topk)) candidates.
+    TOPK_TARGET_GRID = 64
+    MAX_NUM_TOPK_CHUNKS = 16
+    topk_target = max(
+        1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, batch * num_idx_heads))
+    )
+    num_topk_chunks = 1 << (topk_target.bit_length() - 1)
+    block_size_t = triton.next_power_of_2(topk)
+    chunk_blocks = (max_block + num_topk_chunks - 1) // num_topk_chunks
+    topk_score_partial = torch.empty(
+        num_topk_chunks,
+        num_idx_heads,
+        batch,
+        block_size_t,
+        dtype=torch.float32,
+        device=idx_q.device,
+    )
+    topk_idx_partial = torch.empty(
+        num_topk_chunks,
+        num_idx_heads,
+        batch,
+        block_size_t,
+        dtype=torch.int32,
+        device=idx_q.device,
+    )
+    _topk_index_partial_kernel[(batch, num_idx_heads, num_topk_chunks)](
+        score,
+        topk_score_partial,
+        topk_idx_partial,
+        seq_lens,
+        SPARSE_BLOCK_SIZE,
+        topk,
+        chunk_blocks,
+        decode_query_len,
+        score.stride(0),
+        score.stride(1),
+        score.stride(2),
+        topk_score_partial.stride(0),
+        topk_score_partial.stride(1),
+        topk_score_partial.stride(2),
+        topk_score_partial.stride(3),
+        topk_idx_partial.stride(0),
+        topk_idx_partial.stride(1),
+        topk_idx_partial.stride(2),
+        topk_idx_partial.stride(3),
+        USE_PDL=use_pdl,
+        **pdl_kwargs,
+    )
+    _topk_index_merge_kernel[(batch, num_idx_heads)](
+        topk_score_partial,
+        topk_idx_partial,
+        topk_idx,
+        seq_lens,
+        SPARSE_BLOCK_SIZE,
+        topk,
+        decode_query_len,
+        topk_score_partial.stride(0),
+        topk_score_partial.stride(1),
+        topk_score_partial.stride(2),
+        topk_score_partial.stride(3),
+        topk_idx_partial.stride(0),
+        topk_idx_partial.stride(1),
+        topk_idx_partial.stride(2),
+        topk_idx_partial.stride(3),
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        num_topk_chunks=num_topk_chunks,
+        USE_PDL=use_pdl,
+        **pdl_kwargs,
+    )
+    return topk_idx

--- a/src/flag_attn/minimax_sparse_attention/index_topk.py
+++ b/src/flag_attn/minimax_sparse_attention/index_topk.py
@@ -1,5 +1,18 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Triton kernels for MiniMax M3 lightning-indexer block scoring + top-k.
 
 Index queries score each 128-token block of index keys (max over the block),

--- a/src/flag_attn/minimax_sparse_attention/index_topk.py
+++ b/src/flag_attn/minimax_sparse_attention/index_topk.py
@@ -1,18 +1,5 @@
-# Copyright 2026 FlagOS Contributors
-# Copyright contributors to the vLLM project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Triton kernels for MiniMax M3 lightning-indexer block scoring + top-k.
 
 Index queries score each 128-token block of index keys (max over the block),
@@ -30,8 +17,22 @@ feed the block-sparse attention kernels in ``sparse_attn``.
 import torch
 import triton
 import triton.language as tl
+from triton.errors import TritonError
 
-from .utils import current_platform, round_up
+from .utils import current_platform, has_triton_tle, round_up
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        _HAS_TLE = True
+    except ImportError:
+        tle = None
+        _HAS_TLE = False
+else:
+    tle = None
+    _HAS_TLE = False
+
 
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
@@ -196,7 +197,7 @@ def _index_block_score_kernel(
     key=["BLOCK_SIZE_T"],
 )
 @triton.jit(do_not_specialize_on_alignment=["prefix_lens"])
-def _topk_index_kernel(
+def _topk_index_kernel_fallback(
     s_ptr,  # [num_heads, total_q, max_block]
     ti_ptr,  # [num_heads, total_q, topk]
     sample_interval: tl.constexpr,  # block_size_q (1 for M3)
@@ -295,6 +296,380 @@ def _topk_index_kernel(
     valid_mask = off_t < valid_blocks
     topk_idx = tl.where(store_mask & valid_mask, topk_idx, -1)
     tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty), mask=store_mask)
+
+
+# ---------------------------------------------------------------------------
+# Streaming Top-K adapted to MSA prefill semantics.
+#
+# The reference implementation is ``FlagTree/python/tutorials/tle/03-topk.py``
+# and operates on a uniform 2-D [M, N] tensor.  This adapted kernel keeps the
+# MSA row mapping, per-query causal length, forced init/local blocks, NaN
+# handling, output layout, and -1 padding.  Only the row-local selection engine
+# is replaced by the packed-key ``tl.topk`` + ``tl.bitonic_merge`` algorithm.
+#
+# This path intentionally remains separate from ``_topk_index_kernel_fallback``
+# so unsupported shapes preserve the previous behavior.  The streaming
+# implementation uses only standard Triton APIs; it does not depend on TLE.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _streaming_topk_fpval_to_key(x_bits):
+    sign_bit = tl.full(x_bits.shape, 0x80000000, dtype=tl.uint32)
+    full_mask = tl.full(x_bits.shape, 0xFFFFFFFF, dtype=tl.uint32)
+    mask = tl.where((x_bits & sign_bit) != 0, full_mask, sign_bit)
+    return x_bits ^ mask
+
+
+@triton.jit
+def _streaming_topk_index_to_key(index):
+    max_u16 = tl.full(index.shape, 0xFFFF, dtype=tl.uint32)
+    return max_u16 - index.to(tl.uint32)
+
+
+@triton.jit
+def _streaming_topk_key_to_index(index_key):
+    max_u16 = tl.full(index_key.shape, 0xFFFF, dtype=tl.uint32)
+    return (max_u16 - index_key.to(tl.uint32)).to(tl.int32)
+
+
+_MAX_STREAMING_TILE_SIZE = 2048
+_RADIX_BITS = 4
+_RADIX_MIN_PADDED_BLOCKS = 1024
+_RADIX_MAX_TOPK = 64
+_RADIX_MIN_BLOCKS_PER_TOPK = 16
+_FAILED_RADIX_CONFIGS: set[tuple[int, int]] = set()
+
+
+@triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
+@triton.jit(do_not_specialize_on_alignment=["prefix_lens"])
+def _topk_index_kernel_streaming(
+    s_ptr,  # [num_heads, total_q, max_block]
+    ti_ptr,  # [num_heads, total_q, topk]
+    sample_interval: tl.constexpr,  # block_size_q (1 for M3)
+    block_size: tl.constexpr,  # sparse block size (128)
+    cu_seqlens,
+    cu_seqblocks_q,
+    prefix_lens,
+    topk: tl.constexpr,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_h,
+    stride_s_n,
+    stride_s_k,
+    stride_ti_h,
+    stride_ti_n,
+    stride_ti_t,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_T: tl.constexpr,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    tl.static_assert(BLOCK_SIZE_T == topk)
+    tl.static_assert(BLOCK_SIZE_K >= BLOCK_SIZE_T)
+
+    pid_q = tl.program_id(0)
+    pid_b = tl.program_id(1)
+    pid_h = tl.program_id(2)
+    seq_start = tl.load(cu_seqlens + pid_b)
+    block_start = tl.load(cu_seqblocks_q + pid_b)
+    block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q >= block_num:
+        return
+
+    valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    ti_ptrs = (
+        ti_ptr
+        + (block_start + pid_q) * stride_ti_n
+        + pid_h * stride_ti_h
+        + off_t * stride_ti_t
+    )
+
+    # When N <= K every visible block must be selected.  The normal streaming
+    # path also returns these ids in ascending order, so this is exactly the
+    # same output without loading or sorting scores.
+    if valid_blocks <= topk:
+        topk_idx = tl.where(off_t < valid_blocks, off_t, -1)
+        tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty))
+        return
+
+    off_k = tl.arange(0, BLOCK_SIZE_K)
+
+    # Start from the last (possibly partial) tile.  All preceding tiles are
+    # full, matching the order used by the source streaming kernel.
+    num_tiles = tl.cdiv(valid_blocks, BLOCK_SIZE_K)
+    tile_start = (num_tiles - 1) * BLOCK_SIZE_K
+    block_idx = tile_start + off_k
+    causal_mask = block_idx < valid_blocks
+    local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+    init_mask = block_idx < init_blocks
+
+    score_row = (
+        s_ptr + (seq_start + pid_q * sample_interval) * stride_s_n + pid_h * stride_s_h
+    )
+    score = tl.load(
+        score_row + block_idx * stride_s_k,
+        mask=causal_mask,
+        other=-1e30,
+    ).to(tl.float32)
+    score = tl.where(score != score, -1e30, score)
+    if MASK_INIT:
+        score = tl.where(causal_mask & init_mask, score - 1e29, score)
+    else:
+        score = tl.where(causal_mask & init_mask, 1e30, score)
+    if MASK_LOCAL:
+        score = tl.where(causal_mask & local_mask, score - 1e28, score)
+    else:
+        score = tl.where(causal_mask & local_mask, 1e29, score)
+
+    score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+    index_key = _streaming_topk_index_to_key(block_idx)
+    packed = (score_key.to(tl.uint64) << 16) | index_key.to(tl.uint64)
+    # A finite sentinel such as -1e30 is not below every valid FP32 value.
+    # Force lanes outside this row's causal range below the key for -inf so a
+    # partial tile can never return an out-of-range logical block id.
+    packed = tl.where(causal_mask, packed, tl.zeros_like(packed))
+    acc = tl.topk(packed, BLOCK_SIZE_T)
+
+    for _ in tl.range(0, num_tiles - 1):
+        acc = tl.bitonic_merge(acc)
+        tile_start -= BLOCK_SIZE_K
+        block_idx = tile_start + off_k
+        local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+        init_mask = block_idx < init_blocks
+
+        score = tl.load(score_row + block_idx * stride_s_k).to(tl.float32)
+        score = tl.where(score != score, -1e30, score)
+        if MASK_INIT:
+            score = tl.where(init_mask, score - 1e29, score)
+        else:
+            score = tl.where(init_mask, 1e30, score)
+        if MASK_LOCAL:
+            score = tl.where(local_mask, score - 1e28, score)
+        else:
+            score = tl.where(local_mask, 1e29, score)
+
+        score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+        index_key = _streaming_topk_index_to_key(block_idx)
+        packed = (score_key.to(tl.uint64) << 16) | index_key.to(tl.uint64)
+        acc = tl.maximum(acc, tl.topk(packed, BLOCK_SIZE_T))
+
+    # Match the source streaming implementation's output convention: rotate
+    # the index key into the high bits, then sort selected blocks by ascending
+    # logical block id.
+    acc = (acc << 48) | (acc >> 16)
+    acc = tl.sort(acc, descending=True)
+    selected_index_key = (acc >> 48).to(tl.uint32)
+    topk_idx = _streaming_topk_key_to_index(selected_index_key)
+
+    valid_result = (off_t < valid_blocks) & (topk_idx < valid_blocks)
+    topk_idx = tl.where(valid_result, topk_idx, -1)
+    tl.store(ti_ptrs, topk_idx.to(ti_ptrs.dtype.element_ty))
+
+
+# ---------------------------------------------------------------------------
+# TLE shared-memory Radix Select for wide Prefill rows.
+#
+# This adapts ``FlagTree/python/tutorials/tle/03-topk.py`` to MSA metadata.
+# Unlike the tutorial's atomic output compaction, the final pass scans block ids
+# in ascending order and uses prefix sums.  Equal scores therefore use the same
+# smaller-block-id tie-break as the packed-key streaming path.
+# ---------------------------------------------------------------------------
+@triton.jit
+def _load_prefill_topk_score(
+    score_row,
+    block_idx,
+    valid_blocks,
+    init_blocks: tl.constexpr,
+    local_blocks: tl.constexpr,
+    stride_s_k,
+    MASK_INIT: tl.constexpr,
+    MASK_LOCAL: tl.constexpr,
+):
+    valid = block_idx < valid_blocks
+    score = tl.load(
+        score_row + block_idx * stride_s_k,
+        mask=valid,
+        other=-1e30,
+    ).to(tl.float32)
+    score = tl.where(score != score, -1e30, score)
+    init_mask = block_idx < init_blocks
+    local_mask = block_idx >= max(0, valid_blocks - local_blocks)
+    if MASK_INIT:
+        score = tl.where(valid & init_mask, score - 1e29, score)
+    else:
+        score = tl.where(valid & init_mask, 1e30, score)
+    if MASK_LOCAL:
+        score = tl.where(valid & local_mask, score - 1e28, score)
+    else:
+        score = tl.where(valid & local_mask, 1e29, score)
+    return score, valid
+
+
+if _HAS_TLE:
+
+    @triton.jit(do_not_specialize_on_alignment=["prefix_lens"])
+    def _topk_index_kernel_radix_tle(
+        s_ptr,  # [num_heads, total_q, max_block]
+        ti_ptr,  # [num_heads, total_q, topk]
+        sample_interval: tl.constexpr,
+        block_size: tl.constexpr,
+        cu_seqlens,
+        cu_seqblocks_q,
+        prefix_lens,
+        topk: tl.constexpr,
+        init_blocks: tl.constexpr,
+        local_blocks: tl.constexpr,
+        stride_s_h,
+        stride_s_n,
+        stride_s_k,
+        stride_ti_h,
+        stride_ti_n,
+        stride_ti_t,
+        BLOCK_SIZE_K: tl.constexpr,
+        BLOCK_SIZE_T: tl.constexpr,
+        RADIX_BITS: tl.constexpr,
+        MASK_INIT: tl.constexpr,
+        MASK_LOCAL: tl.constexpr,
+    ):
+        tl.static_assert(RADIX_BITS == 4)
+        tl.static_assert(BLOCK_SIZE_T >= topk)
+        RADIX_SIZE: tl.constexpr = 1 << RADIX_BITS
+        RADIX_MASK: tl.constexpr = RADIX_SIZE - 1
+
+        pid_q = tl.program_id(0)
+        pid_b = tl.program_id(1)
+        pid_h = tl.program_id(2)
+        seq_start = tl.load(cu_seqlens + pid_b)
+        block_start = tl.load(cu_seqblocks_q + pid_b)
+        block_num = tl.load(cu_seqblocks_q + pid_b + 1) - block_start
+        prefix_len = tl.load(prefix_lens + pid_b)
+        if pid_q >= block_num:
+            return
+
+        valid_blocks = (prefix_len + pid_q * sample_interval + block_size) // block_size
+        off_t = tl.arange(0, BLOCK_SIZE_T)
+        output_row = ti_ptr + (block_start + pid_q) * stride_ti_n + pid_h * stride_ti_h
+
+        # Per-row Identity path.  It is particularly important for early
+        # Prefill queries, whose causal range has not yet grown beyond K.
+        if valid_blocks <= topk:
+            topk_idx = tl.where(off_t < valid_blocks, off_t, -1)
+            tl.store(
+                output_row + off_t * stride_ti_t,
+                topk_idx.to(ti_ptr.dtype.element_ty),
+                mask=off_t < topk,
+            )
+            return
+
+        score_row = (
+            s_ptr
+            + (seq_start + pid_q * sample_interval) * stride_s_n
+            + pid_h * stride_s_h
+        )
+        lane = tl.arange(0, BLOCK_SIZE_K)
+        bins = tl.arange(0, RADIX_SIZE)
+        one = tl.full([BLOCK_SIZE_K], 1, tl.int32)
+        n_tiles = tl.cdiv(valid_blocks, BLOCK_SIZE_K)
+
+        # The histogram is CTA-local, exactly as in the TLE tutorial.
+        smem_counts = tle.gpu.alloc(
+            [RADIX_SIZE],
+            dtype=tl.int32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
+        )
+        smem_count_ptrs = tle.gpu.local_ptr(smem_counts, (bins,))
+
+        desired = tl.full((), 0, dtype=tl.uint32)
+        desired_mask = tl.full((), 0, dtype=tl.uint32)
+        k_to_find = tl.full((), topk, dtype=tl.int32)
+        radix_mask_u32 = tl.full((), RADIX_MASK, dtype=tl.uint32)
+
+        # Eight 4-bit MSD passes locate the exact FP32 key at the K boundary.
+        for digit_pos in tl.static_range(32 - RADIX_BITS, -1, -RADIX_BITS):
+            tl.store(
+                smem_count_ptrs,
+                tl.zeros([RADIX_SIZE], dtype=tl.int32),
+            )
+            tl.debug_barrier()
+            for tile in tl.range(0, n_tiles):
+                block_idx = tile * BLOCK_SIZE_K + lane
+                score, valid = _load_prefill_topk_score(
+                    score_row,
+                    block_idx,
+                    valid_blocks,
+                    init_blocks,
+                    local_blocks,
+                    stride_s_k,
+                    MASK_INIT,
+                    MASK_LOCAL,
+                )
+                score_key = _streaming_topk_fpval_to_key(
+                    score.to(tl.uint32, bitcast=True)
+                )
+                matches = (score_key & desired_mask) == desired
+                digit = ((score_key >> digit_pos) & RADIX_MASK).to(tl.int32)
+                count_ptrs = tle.gpu.local_ptr(smem_counts, (digit,))
+                tl.atomic_add(
+                    count_ptrs,
+                    one,
+                    mask=valid & matches,
+                    sem="relaxed",
+                    scope="cta",
+                )
+            tl.debug_barrier()
+
+            counts = tl.load(smem_count_ptrs)
+            cumsum_desc = tl.cumsum(counts, axis=0, reverse=True)
+            selected_mask = cumsum_desc >= k_to_find
+            selected = tl.max(tl.where(selected_mask, bins, 0), axis=0).to(tl.int32)
+            counts_gt = tl.max(tl.where(bins == selected + 1, cumsum_desc, 0), axis=0)
+            selected_u32 = selected.to(tl.uint32)
+            desired = desired | (selected_u32 << digit_pos)
+            desired_mask = desired_mask | (radix_mask_u32 << digit_pos)
+            k_to_find = k_to_find - counts_gt
+
+        # At this point ``desired`` is the exact threshold key and
+        # ``k_to_find`` is how many threshold-equal elements are still needed.
+        # Scan once in ascending block-id order, emitting all greater keys and
+        # the first equal keys.  This combines the tutorial's two collection
+        # passes and makes ties deterministic.
+        written = tl.full((), 0, dtype=tl.int32)
+        equal_seen = tl.full((), 0, dtype=tl.int32)
+        for tile in tl.range(0, n_tiles):
+            block_idx = tile * BLOCK_SIZE_K + lane
+            score, valid = _load_prefill_topk_score(
+                score_row,
+                block_idx,
+                valid_blocks,
+                init_blocks,
+                local_blocks,
+                stride_s_k,
+                MASK_INIT,
+                MASK_LOCAL,
+            )
+            score_key = _streaming_topk_fpval_to_key(score.to(tl.uint32, bitcast=True))
+            take_gt = valid & (score_key > desired)
+            take_equal = valid & (score_key == desired)
+            equal_rank = tl.cumsum(take_equal.to(tl.int32), axis=0)
+            take_equal = take_equal & (equal_seen + equal_rank <= k_to_find)
+            take = take_gt | take_equal
+            take_rank = tl.cumsum(take.to(tl.int32), axis=0)
+            out_pos = written + take_rank - 1
+            tl.store(
+                output_row + out_pos * stride_ti_t,
+                block_idx.to(ti_ptr.dtype.element_ty),
+                mask=take,
+            )
+            written = written + tl.sum(take.to(tl.int32), axis=0)
+            equal_seen = equal_seen + tl.sum(
+                (valid & (score_key == desired)).to(tl.int32), axis=0
+            )
+
+else:
+    _topk_index_kernel_radix_tle = None
 
 
 # ---------------------------------------------------------------------------
@@ -404,9 +779,49 @@ def _decode_index_score_kernel(
 
 
 # ---------------------------------------------------------------------------
-# Decode top-k (split-K): per-chunk partial top-k + merge. Forced init/local
-# blocks are already encoded in the scores.
+# Decode top-k: identity for N <= K, otherwise per-chunk partial top-k plus a
+# merge. Forced init/local blocks are already encoded in the scores.
 # ---------------------------------------------------------------------------
+@triton.jit(do_not_specialize=["decode_query_len"])
+def _decode_topk_identity_kernel(
+    ti_final_ptr,  # [num_idx_heads, total_q, topk]
+    seq_lens,  # [num_reqs]
+    block_size: tl.constexpr,
+    topk: tl.constexpr,
+    decode_query_len,
+    stride_tif_h,
+    stride_tif_b,
+    stride_tif_t,
+    BLOCK_SIZE_T: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    """Emit every visible block when the padded maximum cannot exceed K."""
+    pid_b = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    kv_len = tl.maximum(query_pos + 1, 0)
+    num_blocks = (kv_len + block_size - 1) // block_size
+
+    off_t = tl.arange(0, BLOCK_SIZE_T)
+    topk_idx = tl.where(off_t < num_blocks, off_t, -1)
+    tl.store(
+        ti_final_ptr
+        + pid_h * stride_tif_h
+        + pid_b * stride_tif_b
+        + off_t * stride_tif_t,
+        topk_idx.to(ti_final_ptr.dtype.element_ty),
+        mask=off_t < topk,
+    )
+
+
 @triton.heuristics({"BLOCK_SIZE_T": lambda args: triton.next_power_of_2(args["topk"])})
 @triton.autotune(
     configs=[
@@ -716,6 +1131,102 @@ def minimax_m3_index_score(
     return score
 
 
+def _supports_prefill_selector_input(score: torch.Tensor, topk: int) -> bool:
+    """Common correctness boundary for the optimized Prefill selectors."""
+    if score.device.type != "cuda":
+        return False
+    if score.dtype != torch.float32 or score.ndim != 3:
+        return False
+    if topk <= 0 or score.shape[2] <= 0:
+        return False
+    return True
+
+
+def _can_use_radix_prefill_topk(
+    score: torch.Tensor,
+    topk: int,
+    max_query_len: int,
+) -> bool:
+    """Use Radix for a short Prefill chunk over a wide existing context."""
+    if not _HAS_TLE or _topk_index_kernel_radix_tle is None:
+        return False
+    if not _supports_prefill_selector_input(score, topk):
+        return False
+    max_score_blocks = score.shape[2]
+    block_size_k, _ = _radix_prefill_launch_config(max_score_blocks)
+    return (
+        # A chunk no longer than one sparse page keeps per-row valid_blocks
+        # nearly constant.  Full Prefill has N growing from 1 to max_block and
+        # is better served by the single-pass Streaming selector.
+        0 < max_query_len <= SPARSE_BLOCK_SIZE
+        and max_score_blocks >= _RADIX_MIN_PADDED_BLOCKS
+        and topk <= _RADIX_MAX_TOPK
+        and max_score_blocks >= _RADIX_MIN_BLOCKS_PER_TOPK * topk
+        and (block_size_k, topk) not in _FAILED_RADIX_CONFIGS
+    )
+
+
+def _can_use_streaming_prefill_topk(score: torch.Tensor, topk: int) -> bool:
+    """Return whether packed-key Streaming supports this call exactly."""
+    if not _supports_prefill_selector_input(score, topk):
+        return False
+    if topk > _MAX_STREAMING_TILE_SIZE:
+        return False
+    # The streaming selector packs the logical block id into 16 bits and uses
+    # an exact (not padded) compile-time K in ``tl.topk``.
+    if score.shape[2] > 0xFFFF:
+        return False
+    if (topk & (topk - 1)) != 0:
+        return False
+    return True
+
+
+def _select_prefill_topk_path(
+    score: torch.Tensor,
+    topk: int,
+    max_query_len: int,
+) -> str:
+    """Choose an algorithm; correctness support and performance policy differ."""
+    if _can_use_radix_prefill_topk(score, topk, max_query_len):
+        return "radix"
+    if _can_use_streaming_prefill_topk(score, topk):
+        return "streaming"
+    return "fallback"
+
+
+def _topk_tile_num_warps(block_size: int) -> int:
+    if block_size <= 64:
+        return 2
+    if block_size <= 128:
+        return 4
+    return 8
+
+
+def _streaming_prefill_launch_config(
+    max_score_blocks: int,
+    topk: int,
+) -> tuple[int, int]:
+    """Choose Streaming resources from MSA's padded max-block dimension."""
+    # MSA rows have different valid_blocks, but they share this padded upper
+    # bound.  Cap the normal tile at 1024 as in TLE, then enlarge only when K
+    # itself needs more lanes.  No synthetic kernel argument is required.
+    block_size = max(
+        64,
+        topk,
+        triton.next_power_of_2(min(max_score_blocks, 1024)),
+    )
+    return block_size, _topk_tile_num_warps(block_size)
+
+
+def _radix_prefill_launch_config(max_score_blocks: int) -> tuple[int, int]:
+    """Choose Radix resources from MSA's padded max-block dimension."""
+    block_size = max(
+        32,
+        triton.next_power_of_2(min(max_score_blocks, 1024)),
+    )
+    return block_size, _topk_tile_num_warps(block_size)
+
+
 @torch.no_grad()
 def minimax_m3_index_topk(
     score: torch.Tensor,  # [num_idx_heads, total_q, max_block]
@@ -728,6 +1239,11 @@ def minimax_m3_index_topk(
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Select index top-k from a precomputed score tensor.
+
+    Dispatches short Prefill chunks over wide contexts to TLE Radix Select,
+    full/medium Prefill to packed-key Streaming Top-K, and unsupported inputs to
+    the original Bitonic fallback.  Optimized kernels contain a per-row N <= K
+    identity path.
 
     When ``out`` is provided (a ``[num_idx_heads, >=total_q, topk]`` buffer), the
     result is written into ``out[:, :total_q, :]`` instead of a fresh tensor --
@@ -746,7 +1262,7 @@ def minimax_m3_index_topk(
         )
     # block_size_q == 1 -> query blocks coincide with query tokens.
     grid_topk = (max_query_len, batch, num_idx_heads)
-    _topk_index_kernel[grid_topk](
+    kernel_args = (
         score,
         topk_idx,
         1,  # sample_interval (block_size_q)
@@ -763,9 +1279,50 @@ def minimax_m3_index_topk(
         topk_idx.stride(0),
         topk_idx.stride(1),
         topk_idx.stride(2),
-        MASK_INIT=False,
-        MASK_LOCAL=False,
     )
+    path = _select_prefill_topk_path(score, topk, max_query_len)
+    if path == "radix":
+        assert _topk_index_kernel_radix_tle is not None
+        block_size_k, num_warps = _radix_prefill_launch_config(score.shape[2])
+        try:
+            _topk_index_kernel_radix_tle[grid_topk](
+                *kernel_args,
+                BLOCK_SIZE_K=block_size_k,
+                BLOCK_SIZE_T=triton.next_power_of_2(topk),
+                RADIX_BITS=_RADIX_BITS,
+                MASK_INIT=False,
+                MASK_LOCAL=False,
+                num_warps=num_warps,
+                num_stages=1,
+            )
+            return topk_idx
+        except TritonError:
+            # Some CUDA/Triton combinations expose the TLE module but cannot
+            # lower this shared-memory kernel.  Remember the failed compile
+            # configuration so later calls do not repeatedly pay that cost.
+            _FAILED_RADIX_CONFIGS.add((block_size_k, topk))
+            path = (
+                "streaming"
+                if _can_use_streaming_prefill_topk(score, topk)
+                else "fallback"
+            )
+
+    if path == "streaming":
+        block_size_k, num_warps = _streaming_prefill_launch_config(score.shape[2], topk)
+        _topk_index_kernel_streaming[grid_topk](
+            *kernel_args,
+            BLOCK_SIZE_K=block_size_k,
+            MASK_INIT=False,
+            MASK_LOCAL=False,
+            num_warps=num_warps,
+            num_stages=2,
+        )
+    else:
+        _topk_index_kernel_fallback[grid_topk](
+            *kernel_args,
+            MASK_INIT=False,
+            MASK_LOCAL=False,
+        )
     return topk_idx
 
 
@@ -883,7 +1440,7 @@ def minimax_m3_index_decode(
     out: torch.Tensor | None = None,
     score_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    """Decode index block-score + top-k, both split-K (cudagraph-safe).
+    """Decode index block-score + dispatched top-k (cudagraph-safe).
 
     Returns topk_idx [num_kv_heads, total_q, topk] (0-indexed block ids, -1 pad).
     When ``out`` ([num_kv_heads, >=total_q, topk]) is given, writes into
@@ -894,12 +1451,62 @@ def minimax_m3_index_decode(
     via strides, so a transposed view of a block-major buffer is accepted.
     """
     total_q, num_idx_heads, _ = idx_q.shape
+    assert (
+        num_idx_heads == num_kv_heads
+    ), "M3 expects num_idx_heads == num_kv_heads (no topk index reduce)"
+    assert decode_query_len <= max_decode_query_len
+    assert total_q == seq_lens.shape[0] * decode_query_len
     batch = total_q
     max_block = triton.cdiv(max_seq_len, SPARSE_BLOCK_SIZE)
     use_pdl = current_platform.is_arch_support_pdl()
     pdl_kwargs: dict[str, bool | int] = {}
     if use_pdl:
         pdl_kwargs.update({"launch_pdl": True})
+
+    block_size_t = triton.next_power_of_2(topk)
+    if max_block <= topk:
+        # Every visible block is selected, so scores cannot affect the result.
+        # Preserve the documented score_out mutation when the caller supplies
+        # that buffer; otherwise skip both score generation and Top-K sorting.
+        if out is not None:
+            topk_idx = out[:, :total_q, :]
+        else:
+            topk_idx = torch.empty(
+                (num_idx_heads, total_q, topk),
+                dtype=torch.int32,
+                device=idx_q.device,
+            )
+        if score_out is not None:
+            minimax_m3_index_decode_score(
+                idx_q,
+                index_kv_cache,
+                block_table,
+                seq_lens,
+                max_seq_len,
+                init_blocks,
+                local_blocks,
+                num_kv_heads,
+                decode_query_len,
+                max_decode_query_len,
+                score_out=score_out,
+            )
+        identity_use_pdl = use_pdl and score_out is not None
+        identity_pdl_kwargs = pdl_kwargs if identity_use_pdl else {}
+        _decode_topk_identity_kernel[(batch, num_idx_heads)](
+            topk_idx,
+            seq_lens,
+            SPARSE_BLOCK_SIZE,
+            topk,
+            decode_query_len,
+            topk_idx.stride(0),
+            topk_idx.stride(1),
+            topk_idx.stride(2),
+            BLOCK_SIZE_T=block_size_t,
+            USE_PDL=identity_use_pdl,
+            **identity_pdl_kwargs,
+        )
+        return topk_idx
+
     score = minimax_m3_index_decode_score(
         idx_q,
         index_kv_cache,
@@ -922,6 +1529,7 @@ def minimax_m3_index_decode(
             dtype=torch.int32,
             device=idx_q.device,
         )
+
     # Chunk count is shape-constant (cudagraph-safe), capped so the merge sorts
     # pow2(num_topk_chunks * pow2(topk)) candidates.
     TOPK_TARGET_GRID = 64
@@ -930,7 +1538,6 @@ def minimax_m3_index_decode(
         1, min(MAX_NUM_TOPK_CHUNKS, TOPK_TARGET_GRID // max(1, batch * num_idx_heads))
     )
     num_topk_chunks = 1 << (topk_target.bit_length() - 1)
-    block_size_t = triton.next_power_of_2(topk)
     chunk_blocks = (max_block + num_topk_chunks - 1) // num_topk_chunks
     topk_score_partial = torch.empty(
         num_topk_chunks,

--- a/src/flag_attn/minimax_sparse_attention/sparse_attn.py
+++ b/src/flag_attn/minimax_sparse_attention/sparse_attn.py
@@ -1,18 +1,5 @@
-# Copyright 2026 FlagOS Contributors
-# Copyright contributors to the vLLM project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Triton kernels for MiniMax M3 block-sparse GQA attention.
 
 The main heads attend only to the blocks selected by the lightning indexer (see
@@ -32,12 +19,17 @@ leaves the prefill kernels (which parallelize over the query dim) idle.
 
 import torch
 import triton
+import triton.experimental.tle.language as tle
 import triton.language as tl
 
 from .utils import current_platform
 
 # One sparse block == one KV page.
 SPARSE_BLOCK_SIZE = 128
+
+# A 64-token double buffer amortizes its extra softmax/barrier work only for
+# the smallest benchmark GQA tile. Larger tiles reuse one full-page KV stage.
+_PREFILL_HALF_KV_MAX_BLOCK_SIZE_QH = 8
 
 _FP8_DTYPES = (
     torch.float8_e4m3fn,
@@ -54,16 +46,8 @@ _FP8_DTYPES = (
 # since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
 # might lose pointer alignment, which trigger Triton recompiles. we don't actually
 # need pointer alignment for those tensors anyway because we do scalar load.
-@triton.heuristics(
-    {
-        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
-        "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
-        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
-        * triton.next_power_of_2(args["gqa_group_size"]),
-    }
-)
 @triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
-def _gqa_sparse_fwd_kernel(
+def _gqa_sparse_fwd_direct(
     q_ptr,  # [total_q, num_heads, head_dim]
     kv_cache_ptr,  # main cache: [num_blocks, num_kv_heads, 128, 2*head_dim]
     k_scale_ptr,
@@ -111,7 +95,6 @@ def _gqa_sparse_fwd_kernel(
     pid_q = tl.program_id(0)
     pid_kh = tl.program_id(1)
     pid_b = tl.program_id(2)
-    pid_h = pid_kh * gqa_group_size
     q_start = tl.load(cu_seqlens_q + pid_b)
     q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
     q_block_start = tl.load(cu_seqblocks_q + pid_b)
@@ -123,8 +106,11 @@ def _gqa_sparse_fwd_kernel(
     real_q_loop = min(num_q_loop, q_block_len - pid_q * num_q_loop)
     bt_row = block_table_ptr + pid_b * stride_bt_b
     off_n = tl.arange(0, BLOCK_SIZE_K)
-    off_d = tl.arange(0, BLOCK_SIZE_D)
-    d_mask = off_d < head_dim
+    if USE_FP8 and KV_SCALE_MODE == 1:
+        # Scalar scales are invariant across every selected page. Fold K into
+        # the logits scale and delay V until the normalized output.
+        qk_scale = sm_scale_log2e * tl.load(k_scale_ptr)
+        v_scale_scalar = tl.load(v_scale_ptr)
     for j in range(real_q_loop):
         pid_q_j = pid_q * num_q_loop + j
         t_ptr_j = t_ptr + (q_block_start + pid_q_j) * stride_tn + pid_kh * stride_th
@@ -133,7 +119,7 @@ def _gqa_sparse_fwd_kernel(
         valid_blocks = (q_abs + BLOCK_SIZE_K) // BLOCK_SIZE_K
         real_topk = tl.minimum(max_topk, valid_blocks)
         q_ptrs = tl.make_block_ptr(
-            base=q_ptr + q_start * stride_qn + pid_h * stride_qh,
+            base=q_ptr + q_start * stride_qn + pid_kh * gqa_group_size * stride_qh,
             shape=(q_len, gqa_group_size, head_dim),
             strides=(stride_qn, stride_qh, stride_qd),
             offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
@@ -148,30 +134,48 @@ def _gqa_sparse_fwd_kernel(
             - tl.arange(0, BLOCK_SIZE_K)[None, :]
         )
         m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
-        lse_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+
+        l_i = tl.zeros((BLOCK_SIZE_QH,), dtype=tl.float32)
+        # Keep the direct kernel's PV accumulator in [QH, D] order.  The
+        # transposed [D, QH] form spills heavily for the FP8 QH=32 tile.
         acc_o = tl.zeros((BLOCK_SIZE_QH, BLOCK_SIZE_D), dtype=tl.float32)
         q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+        if USE_FP8:
+            # Keep QK in FP8 Tensor Core form.  Q is per-head dynamically
+            # scaled once, then its scale is restored on the FP32 logits.
+            # This keeps the existing K cache in FP8 through tl.dot instead
+            # of materializing a BF16 K tile for every selected page.
+            qk_q_scale = tl.maximum(
+                tl.max(tl.abs(q), axis=1) * (1.0 / 448.0), 1.0e-8
+            )
+            q_qk = (q / qk_q_scale[:, None]).to(tl.float8e4nv)
+        else:
+            q_qk = q
         for _ in range(real_topk):
             blk = tl.load(t_ptr_j).to(tl.int32)
             t_ptr_j = t_ptr_j + stride_tk
             c = blk * BLOCK_SIZE_K
             page = tl.load(bt_row + blk).to(tl.int64)
+
             pos = c + off_n
             pos_mask = pos < seq_len
+
+            k_base_ptr = kv_cache_ptr + page * stride_kv_blk + pid_kh * stride_kv_h
+            k_ptrs = tl.make_block_ptr(
+                base=k_base_ptr,
+                shape=(BLOCK_SIZE_K, head_dim),
+                strides=(stride_kv_pos, stride_kv_d),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_D),
+                order=(1, 0),
+            )
             k = tl.load(
-                kv_cache_ptr
-                + page * stride_kv_blk
-                + pid_kh * stride_kv_h
-                + off_n[None, :] * stride_kv_pos
-                + off_d[:, None] * stride_kv_d,
-                mask=d_mask[:, None] & pos_mask[None, :],
-                other=0.0,
+                k_ptrs,
+                boundary_check=(0, 1),
+                padding_option="zero",
             )
             if USE_FP8:
-                k = k.to(q.dtype)
-                if KV_SCALE_MODE == 1:
-                    k = (k * tl.load(k_scale_ptr)).to(q.dtype)
-                elif KV_SCALE_MODE == 2:
+                if KV_SCALE_MODE == 2:
                     k_scale = tl.load(
                         k_scale_ptr
                         + pid_kh * stride_ks_h
@@ -179,31 +183,58 @@ def _gqa_sparse_fwd_kernel(
                         mask=pos_mask,
                         other=1.0,
                     )
-                    k = (k * k_scale[None, :]).to(q.dtype)
+            qk_dot = tl.dot(q_qk, tl.trans(k))
+            if USE_FP8:
+                qk_dot *= qk_q_scale[:, None]
+
+            is_full_causal = (c + BLOCK_SIZE_K) <= q_abs
+            is_full_seq    = (c + BLOCK_SIZE_K) <= seq_len
+
             qk = tl.zeros((BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
-            # causal: q_abs_pos - k_off >= block_start (c)
-            qk += tl.where(off_q[:, None, :] >= c, 0, float("-inf"))
+            if not is_full_causal:
+                qk += tl.where(off_q[:, None, :] >= c, 0, float("-inf"))
+
             qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
-            qk += tl.dot(q, k) * sm_scale_log2e
-            qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+            if USE_FP8:
+                if KV_SCALE_MODE == 1:
+                    qk += qk_dot * qk_scale
+                elif KV_SCALE_MODE == 2:
+                    # Q @ (K * scale[token]) is equivalent to scaling the
+                    # smaller [QH, K] logits instead of the [K, D] K tile.
+                    qk += qk_dot * (sm_scale_log2e * k_scale[None, :])
+                else:
+                    qk += qk_dot * sm_scale_log2e
+            else:
+                qk += qk_dot * sm_scale_log2e
+
+            if not is_full_seq:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
             m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
             p = tl.exp2(qk - m_ij[:, None])
             l_ij = tl.sum(p, axis=1)
-            acc_o = acc_o * tl.exp2(m_i - m_ij)[:, None]
-            v = tl.load(
-                kv_cache_ptr
-                + page * stride_kv_blk
-                + pid_kh * stride_kv_h
-                + off_n[:, None] * stride_kv_pos
-                + (head_dim + off_d[None, :]) * stride_kv_d,
-                mask=pos_mask[:, None] & d_mask[None, :],
-                other=0.0,
+
+            alpha = tl.exp2(m_i - m_ij)
+            acc_o = acc_o * alpha[:, None]
+            l_i = l_i * alpha + l_ij
+
+            v_base_ptr = k_base_ptr + head_dim * stride_kv_d
+            v_ptrs = tl.make_block_ptr(
+                base=v_base_ptr,
+                shape=(BLOCK_SIZE_K, head_dim),
+                strides=(stride_kv_pos, stride_kv_d),
+                offsets=(0, 0),
+                block_shape=(BLOCK_SIZE_K, BLOCK_SIZE_D),
+                order=(1, 0),
             )
+            v = tl.load(
+                v_ptrs,
+                boundary_check=(0, 1),
+                padding_option="zero",
+            )
+
             if USE_FP8:
-                v = v.to(q.dtype)
-                if KV_SCALE_MODE == 1:
-                    v = (v * tl.load(v_scale_ptr)).to(q.dtype)
-                elif KV_SCALE_MODE == 2:
+                if KV_SCALE_MODE == 2:
                     v_scale = tl.load(
                         v_scale_ptr
                         + pid_kh * stride_vs_h
@@ -211,14 +242,37 @@ def _gqa_sparse_fwd_kernel(
                         mask=pos_mask,
                         other=1.0,
                     )
-                    v = (v * v_scale[:, None]).to(q.dtype)
-            acc_o += tl.dot(p.to(v.dtype), v)
+
+            if USE_FP8 and BLOCK_SIZE_H < 32:
+                # The 8/16-head tiles lower efficiently as FP8 PV MMAs.
+                # Fold a per-token V scale into P before quantizing P
+                # row-wise, and keep V in its FP8 cache format.
+                pv_p = p
+                if KV_SCALE_MODE == 2:
+                    pv_p *= v_scale[None, :]
+                pv_p_scale = tl.maximum(
+                    tl.max(tl.abs(pv_p), axis=1) * (1.0 / 448.0), 1.0e-8
+                )
+                p_dot = (pv_p / pv_p_scale[:, None]).to(tl.float8e4nv)
+                acc_o += tl.dot(p_dot, v) * pv_p_scale[:, None]
+            else:
+                # QH=32 uses the native PV accumulator layout above, but its
+                # FP8 PV lowering spills heavily; retain BF16 operands there.
+                if USE_FP8:
+                    v = v.to(q.dtype)
+                p_dot = p.to(v.dtype)
+                if USE_FP8 and KV_SCALE_MODE == 2:
+                    p_dot = (p * v_scale[None, :]).to(v.dtype)
+                acc_o += tl.dot(p_dot, v)
             m_i = m_ij
-            lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
-        acc_o = acc_o * tl.exp2(m_i - lse_i)[:, None]
+
+        inv_l = tl.where(l_i > 0, 1.0 / l_i, 0.0)
+        if USE_FP8 and KV_SCALE_MODE == 1:
+            inv_l *= v_scale_scalar
+        acc_o = acc_o * inv_l[:, None]
         acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
         o_ptrs = tl.make_block_ptr(
-            base=o_ptr + q_start * stride_on + pid_h * stride_oh,
+            base=o_ptr + q_start * stride_on + pid_kh * gqa_group_size * stride_oh,
             shape=(q_len, gqa_group_size, head_dim),
             strides=(stride_on, stride_oh, stride_od),
             offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
@@ -226,6 +280,440 @@ def _gqa_sparse_fwd_kernel(
             order=(2, 1, 0),
         )
         tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
+
+
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+        "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
+        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
+        * triton.next_power_of_2(args["gqa_group_size"]),
+    }
+)
+@triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _gqa_sparse_fwd_kernel(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    kv_cache_desc,  # flattened [num_blocks*num_kv_heads*128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # [total_q, num_heads, head_dim]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens_q,
+    cu_seqblocks_q,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    num_q_loop,
+    sm_scale,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_on,
+    stride_oh,
+    stride_od,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_QH: tl.constexpr,
+    USE_DIRECT: tl.constexpr,
+    USE_FP8: tl.constexpr,
+    KV_SCALE_MODE: tl.constexpr,
+    USE_HALF_KV_PIPE: tl.constexpr,
+):
+    if USE_DIRECT:
+        _gqa_sparse_fwd_direct(
+            q_ptr,
+            kv_cache_ptr,
+            k_scale_ptr,
+            v_scale_ptr,
+            t_ptr,
+            o_ptr,
+            block_table_ptr,
+            cu_seqlens_q,
+            cu_seqblocks_q,
+            seq_lens,
+            prefix_lens,
+            num_kv_heads,
+            gqa_group_size,
+            head_dim,
+            max_topk,
+            num_q_loop,
+            sm_scale,
+            stride_qn,
+            stride_qh,
+            stride_qd,
+            stride_kv_blk,
+            stride_kv_h,
+            stride_kv_pos,
+            stride_kv_d,
+            stride_ks_h,
+            stride_ks_t,
+            stride_vs_h,
+            stride_vs_t,
+            stride_th,
+            stride_tn,
+            stride_tk,
+            stride_on,
+            stride_oh,
+            stride_od,
+            stride_bt_b,
+            BLOCK_SIZE_Q,
+            BLOCK_SIZE_K,
+            BLOCK_SIZE_D,
+            BLOCK_SIZE_H,
+            BLOCK_SIZE_QH,
+            USE_FP8,
+            KV_SCALE_MODE,
+        )
+        return
+
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_q = tl.program_id(0)
+    pid_kh = tl.program_id(1)
+    pid_b = tl.program_id(2)
+    pid_h = pid_kh * gqa_group_size
+    q_start = tl.load(cu_seqlens_q + pid_b)
+    q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
+    q_block_start = tl.load(cu_seqblocks_q + pid_b)
+    q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+
+    q_tile_start = pid_q * BLOCK_SIZE_Q
+    if q_tile_start >= q_block_len:
+        return
+
+    off_q = tl.arange(0, BLOCK_SIZE_Q)
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    q_abs = prefix_len + q_tile_start + off_q
+    real_topk = tl.minimum(max_topk, (q_abs + BLOCK_SIZE_K) // BLOCK_SIZE_K)
+
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + q_start * stride_qn + pid_h * stride_qh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_qn, stride_qh, stride_qd),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1, 2), padding_option="zero")
+    q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+
+    # Four warps form one Hopper warpgroup. Q is staged once and reused by all
+    # selected pages as the transposed WGMMA B operand.
+    q_smem = tle.gpu.alloc(
+        [1, BLOCK_SIZE_QH, BLOCK_SIZE_D],
+        dtype=q_ptr.dtype.element_ty,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    tl.store(tle.gpu.local_ptr(q_smem.slot(0)), q)
+    tl.debug_barrier()
+
+    m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+    l_i = tl.zeros((BLOCK_SIZE_QH,), dtype=tl.float32)
+    acc_o_t = tl.zeros((BLOCK_SIZE_D, BLOCK_SIZE_QH), dtype=tl.float32)
+
+    loop_blocks = tl.max(real_topk, axis=0)
+    topk_ptr = t_ptr + pid_kh * stride_th + (q_block_start + q_tile_start) * stride_tn
+
+    if USE_HALF_KV_PIPE:
+        HALF_K: tl.constexpr = BLOCK_SIZE_K // 2
+        off_half = tl.arange(0, HALF_K)
+        causal_offsets = q_abs[:, None] - off_half[None, :]
+        p_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_QH, HALF_K],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_smem = tle.gpu.alloc(
+            [2, HALF_K, BLOCK_SIZE_D],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_stage_bytes: tl.constexpr = HALF_K * BLOCK_SIZE_D * 2
+        kv_empty = tle.gpu.alloc_barriers(
+            num_barriers=2,
+            arrive_count=1,
+            init=tle.gpu.READY,
+        )
+        kv_full = tle.gpu.alloc_barriers(
+            num_barriers=2,
+            arrive_count=1,
+            expect_bytes=kv_stage_bytes,
+        )
+        loop_tiles = loop_blocks * 2
+        # The K prefetch already resolves the next tile's logical block and
+        # physical page. Keep these two scalar addresses live across the loop
+        # so the V copy does not reload topk_idx and block_table for that tile.
+        cur_kv_row = tl.full((), 0, dtype=tl.int32)
+        cur_c = tl.full((), 0, dtype=tl.int32)
+
+        # Prologue: stage the first K half before entering the ping-pong loop.
+        if loop_tiles > 0:
+            first_blk = tl.load(topk_ptr).to(tl.int32)
+            first_page = tl.load(bt_row + first_blk).to(tl.int32)
+            first_row = (first_page * num_kv_heads + pid_kh) * BLOCK_SIZE_K
+            cur_kv_row = first_row
+            cur_c = first_blk * BLOCK_SIZE_K
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=0)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [HALF_K, BLOCK_SIZE_D],
+                [first_row, 0],
+                barrier=kv_full[0],
+            )
+
+        for tile_iter in tl.range(loop_tiles, disable_licm=True, num_stages=1):
+            block_iter = tile_iter // 2
+            # half_idx = tile_iter % 2
+            buf_idx = tile_iter % 2
+            reuse_iter = tile_iter // 2
+            k_phase = reuse_iter * 2
+            v_phase = k_phase + 1
+
+            kv_row = cur_kv_row
+            c = cur_c
+            pos = c + off_half
+            pos_mask = pos < seq_len
+
+            tle.gpu.barrier_wait(kv_full[buf_idx], phaseIdx=k_phase)
+            qk_t = tle.gpu.wgmma(
+                kv_smem.slot(buf_idx),
+                q_smem.slot(0),
+                out_dtype=tl.float32,
+                trans_b=True,
+            )
+            qk_t = tle.gpu.wgmma_wait(0, qk_t)
+            qk_t *= sm_scale_log2e
+            qk = tl.reshape(
+                tl.trans(qk_t),
+                (BLOCK_SIZE_Q, BLOCK_SIZE_H, HALF_K),
+            )
+
+            # Reuse this slot for V while the other slot receives the next K.
+            tle.gpu.barrier_arrive(kv_empty[buf_idx], phaseIdx=k_phase)
+            tle.gpu.barrier_wait(kv_empty[buf_idx], phaseIdx=v_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(buf_idx),
+                [HALF_K, BLOCK_SIZE_D],
+                [kv_row, BLOCK_SIZE_D],
+                barrier=kv_full[buf_idx],
+            )
+
+            if tile_iter + 1 < loop_tiles:
+                next_tile = tile_iter + 1
+                next_block_iter = next_tile // 2
+                next_half_idx = next_tile % 2
+                next_buf_idx = next_tile % 2
+                next_reuse_iter = next_tile // 2
+                next_k_phase = next_reuse_iter * 2
+                next_blk = tl.load(
+                    topk_ptr + next_block_iter * stride_tk
+                ).to(tl.int32)
+                next_page = tl.load(bt_row + next_blk).to(tl.int32)
+                next_kv_row = (
+                    next_page * num_kv_heads + pid_kh
+                ) * BLOCK_SIZE_K + next_half_idx * HALF_K
+                next_c = next_blk * BLOCK_SIZE_K + next_half_idx * HALF_K
+                tle.gpu.barrier_wait(
+                    kv_empty[next_buf_idx], phaseIdx=next_k_phase
+                )
+                tle.gpu.copy(
+                    kv_cache_desc,
+                    kv_smem.slot(next_buf_idx),
+                    [HALF_K, BLOCK_SIZE_D],
+                    [next_kv_row, 0],
+                    barrier=kv_full[next_buf_idx],
+                )
+                cur_kv_row = next_kv_row
+                cur_c = next_c
+
+            if (c + HALF_K) > (prefix_len + q_tile_start):
+                qk += tl.where(causal_offsets[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, HALF_K)
+            if (c + HALF_K) > seq_len:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            alpha = tl.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, axis=1)
+            acc_o_t *= alpha[None, :]
+            tl.store(
+                tle.gpu.local_ptr(p_smem.slot(0)),
+                p.to(kv_cache_ptr.dtype.element_ty),
+            )
+
+            tle.gpu.barrier_wait(kv_full[buf_idx], phaseIdx=v_phase)
+            tl.debug_barrier()
+            acc_o_t = tle.gpu.wgmma(
+                kv_smem.slot(buf_idx),
+                p_smem.slot(0),
+                acc_o_t,
+                trans_a=True,
+                trans_b=True,
+            )
+            acc_o_t = tle.gpu.wgmma_wait(0, acc_o_t)
+            tle.gpu.barrier_arrive(kv_empty[buf_idx], phaseIdx=v_phase)
+
+            l_i = tl.math.fma(l_i, alpha, l_ij)
+            m_i = m_ij
+    else:
+        causal_offsets = q_abs[:, None] - off_n[None, :]
+        p_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_QH, BLOCK_SIZE_K],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_smem = tle.gpu.alloc(
+            [1, BLOCK_SIZE_K, BLOCK_SIZE_D],
+            dtype=kv_cache_ptr.dtype.element_ty,
+            layout=None,
+            scope=tle.gpu.smem,
+        )
+        kv_stage_bytes: tl.constexpr = BLOCK_SIZE_K * BLOCK_SIZE_D * 2
+        kv_empty = tle.gpu.alloc_barriers(
+            num_barriers=1,
+            arrive_count=1,
+            init=tle.gpu.READY,
+        )
+        kv_full = tle.gpu.alloc_barriers(
+            num_barriers=1,
+            arrive_count=1,
+            expect_bytes=kv_stage_bytes,
+        )
+        # Resolve page(0) before the loop. Each iteration consumes the carried
+        # row/offset, then resolves page(i + 1) while V(i) is in flight.
+        cur_kv_row = tl.full((), 0, dtype=tl.int32)
+        cur_c = tl.full((), 0, dtype=tl.int32)
+        if loop_blocks > 0:
+            first_blk = tl.load(topk_ptr).to(tl.int32)
+            first_page = tl.load(bt_row + first_blk).to(tl.int32)
+            cur_kv_row = (
+                first_page * num_kv_heads + pid_kh
+            ) * BLOCK_SIZE_K
+            cur_c = first_blk * BLOCK_SIZE_K
+
+        for block_iter in tl.range(loop_blocks, disable_licm=True, num_stages=1):
+            k_phase = block_iter * 2
+            v_phase = k_phase + 1
+            kv_row = cur_kv_row
+            c = cur_c
+            pos = c + off_n
+            pos_mask = pos < seq_len
+
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=k_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [BLOCK_SIZE_K, BLOCK_SIZE_D],
+                [kv_row, 0],
+                barrier=kv_full[0],
+            )
+            tle.gpu.barrier_wait(kv_full[0], phaseIdx=k_phase)
+
+            qk_t = tle.gpu.wgmma(
+                kv_smem.slot(0),
+                q_smem.slot(0),
+                out_dtype=tl.float32,
+                trans_b=True,
+            )
+            qk_t = tle.gpu.wgmma_wait(0, qk_t)
+            qk_t *= sm_scale_log2e
+            qk = tl.reshape(
+                tl.trans(qk_t),
+                (BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K),
+            )
+
+            tle.gpu.barrier_arrive(kv_empty[0], phaseIdx=k_phase)
+            tle.gpu.barrier_wait(kv_empty[0], phaseIdx=v_phase)
+            tle.gpu.copy(
+                kv_cache_desc,
+                kv_smem.slot(0),
+                [BLOCK_SIZE_K, BLOCK_SIZE_D],
+                [kv_row, BLOCK_SIZE_D],
+                barrier=kv_full[0],
+            )
+
+            if block_iter + 1 < loop_blocks:
+                next_blk = tl.load(
+                    topk_ptr + (block_iter + 1) * stride_tk
+                ).to(tl.int32)
+                next_page = tl.load(bt_row + next_blk).to(tl.int32)
+                cur_kv_row = (
+                    next_page * num_kv_heads + pid_kh
+                ) * BLOCK_SIZE_K
+                cur_c = next_blk * BLOCK_SIZE_K
+
+            if (c + BLOCK_SIZE_K) > (prefix_len + q_tile_start):
+                qk += tl.where(causal_offsets[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
+            if (c + BLOCK_SIZE_K) > seq_len:
+                qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            alpha = tl.exp2(m_i - m_ij)
+            l_ij = tl.sum(p, axis=1)
+            acc_o_t *= alpha[None, :]
+            tl.store(
+                tle.gpu.local_ptr(p_smem.slot(0)),
+                p.to(kv_cache_ptr.dtype.element_ty),
+            )
+
+            tle.gpu.barrier_wait(kv_full[0], phaseIdx=v_phase)
+            tl.debug_barrier()
+            acc_o_t = tle.gpu.wgmma(
+                kv_smem.slot(0),
+                p_smem.slot(0),
+                acc_o_t,
+                trans_a=True,
+                trans_b=True,
+            )
+            acc_o_t = tle.gpu.wgmma_wait(0, acc_o_t)
+            tle.gpu.barrier_arrive(kv_empty[0], phaseIdx=v_phase)
+
+            l_i = tl.math.fma(l_i, alpha, l_ij)
+            m_i = m_ij
+
+    inv_l = tl.where(l_i > 0, 1.0 / l_i, 0.0)
+    acc_o_t *= inv_l[None, :]
+    acc_o = tl.trans(acc_o_t)
+    acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + q_start * stride_on + pid_h * stride_oh,
+        shape=(q_len, gqa_group_size, head_dim),
+        strides=(stride_on, stride_oh, stride_od),
+        offsets=(q_tile_start, 0, 0),
+        block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(2, 1, 0),
+    )
+    tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
 
 
 # ---------------------------------------------------------------------------
@@ -498,7 +986,7 @@ def _kv_scale_args(
     if k_scale is None or v_scale is None:
         raise ValueError("k_scale and v_scale must be both provided or both None")
     if k_scale.device != output.device or v_scale.device != output.device:
-        raise ValueError("k_scale and v_scale must be on the same device as output")
+        raise ValueError("k_scale and v_scale must be on the same dvice as output")
     if k_scale.numel() == 1 and v_scale.numel() == 1:
         return k_scale, v_scale, 0, 0, 0, 0, _KV_SCALE_SCALAR
     if k_scale.dim() == 2 and v_scale.dim() == 2:
@@ -568,16 +1056,91 @@ def minimax_m3_sparse_attn(
         )
     )
     grid = (max_query_len, num_kv_heads, batch)
+    block_size_h = triton.next_power_of_2(gqa_group_size)
+
+    # Keep cases that cannot form a legal WGMMA result out of the TLE kernel:
+    # FP8 KV has a dtype mismatch with BF16 Q, and a GQA tile below eight heads
+    # has an illegal WGMMA N dimension.
+    if use_fp8 or block_size_h < 8:
+        _gqa_sparse_fwd_direct[grid](
+            q,
+            kv_cache,
+            k_scale_arg,
+            v_scale_arg,
+            topk_idx,
+            output,
+            block_table,
+            cu_seqlens_q,
+            cu_seqlens_q,
+            seq_lens,
+            prefix_lens,
+            num_kv_heads,
+            gqa_group_size,
+            head_dim,
+            topk,
+            1,  # num_q_loop
+            sm_scale,
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            kv_cache.stride(0),
+            kv_cache.stride(1),
+            kv_cache.stride(2),
+            kv_cache.stride(3),
+            stride_ks_h,
+            stride_ks_t,
+            stride_vs_h,
+            stride_vs_t,
+            topk_idx.stride(0),
+            topk_idx.stride(1),
+            topk_idx.stride(2),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            block_table.stride(0),
+            BLOCK_SIZE_Q=1,
+            BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+            BLOCK_SIZE_D=triton.next_power_of_2(head_dim),
+            BLOCK_SIZE_H=block_size_h,
+            BLOCK_SIZE_QH=block_size_h,
+            USE_FP8=use_fp8,
+            KV_SCALE_MODE=kv_scale_mode,
+            num_warps=4,
+            num_stages=3,
+        )
+        return
+
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=kv_cache.device)
+
+    triton.set_allocator(alloc_fn)
+    use_direct = False
+    use_half_kv_pipe = (
+        not use_direct and block_size_h <= _PREFILL_HALF_KV_MAX_BLOCK_SIZE_QH
+    )
+    kv_tma_rows = SPARSE_BLOCK_SIZE // 2 if use_half_kv_pipe else SPARSE_BLOCK_SIZE
+    kv_cache_2d = kv_cache.view(-1, 2 * head_dim)
+    kv_cache_desc = TensorDescriptor(
+        kv_cache_2d,
+        shape=[kv_cache_2d.shape[0], kv_cache_2d.shape[1]],
+        strides=[kv_cache_2d.stride(0), kv_cache_2d.stride(1)],
+        block_shape=[kv_tma_rows, head_dim],
+    )
     _gqa_sparse_fwd_kernel[grid](
         q,
         kv_cache,
+        kv_cache_desc,
         k_scale_arg,
         v_scale_arg,
         topk_idx,
         output,
         block_table,
         cu_seqlens_q,
-        cu_seqlens_q,  # cu_seqblocks_q == cu_seqlens_q when block_size_q == 1
+        cu_seqlens_q,
         seq_lens,
         prefix_lens,
         num_kv_heads,
@@ -606,8 +1169,12 @@ def minimax_m3_sparse_attn(
         block_table.stride(0),
         BLOCK_SIZE_Q=1,
         BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        USE_DIRECT=use_direct,
         USE_FP8=use_fp8,
         KV_SCALE_MODE=kv_scale_mode,
+        USE_HALF_KV_PIPE=use_half_kv_pipe,
+        num_warps=4,
+        num_stages=3 if use_direct else 1,
     )
 
 

--- a/src/flag_attn/minimax_sparse_attention/sparse_attn.py
+++ b/src/flag_attn/minimax_sparse_attention/sparse_attn.py
@@ -1,5 +1,18 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Triton kernels for MiniMax M3 block-sparse GQA attention.
 
 The main heads attend only to the blocks selected by the lightning indexer (see

--- a/src/flag_attn/minimax_sparse_attention/sparse_attn.py
+++ b/src/flag_attn/minimax_sparse_attention/sparse_attn.py
@@ -1,0 +1,736 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Triton kernels for MiniMax M3 block-sparse GQA attention.
+
+The main heads attend only to the blocks selected by the lightning indexer (see
+``index_topk``). Adapted to vLLM's paged KV cache: the KV page size is forced to
+equal the sparse block size (128), so one selected block maps to exactly one
+page.
+
+Main K/V cache layout (vLLM):
+  ``(num_blocks, num_kv_heads, 128, 2 * head_dim)``
+  K=[..., :head_dim] V=[..., head_dim:]
+
+Only the paths MiniMax M3 uses are implemented: no attention sink, base-2
+(exp2/log2) softmax. The decode kernels use split-K (flash-decoding) over the
+selected blocks with a separate merge step, since one query token per request
+leaves the prefill kernels (which parallelize over the query dim) idle.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from .utils import current_platform
+
+# One sparse block == one KV page.
+SPARSE_BLOCK_SIZE = 128
+
+_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+    torch.float8_e5m2fnuz,
+)
+
+
+# ---------------------------------------------------------------------------
+# GQA block-sparse attention (paged). Main heads attend only to the selected
+# blocks. BLOCK_SIZE_K == 128 so each selected block is one page.
+# ---------------------------------------------------------------------------
+# since prefill metadata is sliced from mixed batch metadata, seq_lens and prefix_lens
+# might lose pointer alignment, which trigger Triton recompiles. we don't actually
+# need pointer alignment for those tensors anyway because we do scalar load.
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+        "BLOCK_SIZE_H": lambda args: triton.next_power_of_2(args["gqa_group_size"]),
+        "BLOCK_SIZE_QH": lambda args: args["BLOCK_SIZE_Q"]
+        * triton.next_power_of_2(args["gqa_group_size"]),
+    }
+)
+@triton.jit(do_not_specialize_on_alignment=["seq_lens", "prefix_lens"])
+def _gqa_sparse_fwd_kernel(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # main cache: [num_blocks, num_kv_heads, 128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # [total_q, num_heads, head_dim]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    cu_seqlens_q,
+    cu_seqblocks_q,
+    seq_lens,
+    prefix_lens,
+    num_kv_heads,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    num_q_loop,
+    sm_scale,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_on,
+    stride_oh,
+    stride_od,
+    stride_bt_b,
+    BLOCK_SIZE_Q: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    BLOCK_SIZE_D: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_QH: tl.constexpr,
+    USE_FP8: tl.constexpr,  # fp8 KV cache: dequantize K/V to q.dtype on load
+    KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
+):
+    sm_scale_log2e = sm_scale * 1.4426950409
+    pid_q = tl.program_id(0)
+    pid_kh = tl.program_id(1)
+    pid_b = tl.program_id(2)
+    pid_h = pid_kh * gqa_group_size
+    q_start = tl.load(cu_seqlens_q + pid_b)
+    q_len = tl.load(cu_seqlens_q + pid_b + 1) - q_start
+    q_block_start = tl.load(cu_seqblocks_q + pid_b)
+    q_block_len = tl.load(cu_seqblocks_q + pid_b + 1) - q_block_start
+    seq_len = tl.load(seq_lens + pid_b)
+    prefix_len = tl.load(prefix_lens + pid_b)
+    if pid_q * num_q_loop >= q_block_len:
+        return
+    real_q_loop = min(num_q_loop, q_block_len - pid_q * num_q_loop)
+    bt_row = block_table_ptr + pid_b * stride_bt_b
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    d_mask = off_d < head_dim
+    for j in range(real_q_loop):
+        pid_q_j = pid_q * num_q_loop + j
+        t_ptr_j = t_ptr + (q_block_start + pid_q_j) * stride_tn + pid_kh * stride_th
+        # Valid block count from seq position (no sentinel): block_size_q == 1.
+        q_abs = prefix_len + pid_q_j * BLOCK_SIZE_Q
+        valid_blocks = (q_abs + BLOCK_SIZE_K) // BLOCK_SIZE_K
+        real_topk = tl.minimum(max_topk, valid_blocks)
+        q_ptrs = tl.make_block_ptr(
+            base=q_ptr + q_start * stride_qn + pid_h * stride_qh,
+            shape=(q_len, gqa_group_size, head_dim),
+            strides=(stride_qn, stride_qh, stride_qd),
+            offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
+            block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+            order=(2, 1, 0),
+        )
+        q = tl.load(q_ptrs, boundary_check=(0, 1, 2), padding_option="zero")
+        off_q = (
+            tl.arange(0, BLOCK_SIZE_Q)[:, None]
+            + pid_q_j * BLOCK_SIZE_Q
+            + prefix_len
+            - tl.arange(0, BLOCK_SIZE_K)[None, :]
+        )
+        m_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+        lse_i = tl.full((BLOCK_SIZE_QH,), float("-inf"), dtype=tl.float32)
+        acc_o = tl.zeros((BLOCK_SIZE_QH, BLOCK_SIZE_D), dtype=tl.float32)
+        q = tl.reshape(q, BLOCK_SIZE_QH, BLOCK_SIZE_D)
+        for _ in range(real_topk):
+            blk = tl.load(t_ptr_j).to(tl.int32)
+            t_ptr_j = t_ptr_j + stride_tk
+            c = blk * BLOCK_SIZE_K
+            page = tl.load(bt_row + blk).to(tl.int64)
+            pos = c + off_n
+            pos_mask = pos < seq_len
+            k = tl.load(
+                kv_cache_ptr
+                + page * stride_kv_blk
+                + pid_kh * stride_kv_h
+                + off_n[None, :] * stride_kv_pos
+                + off_d[:, None] * stride_kv_d,
+                mask=d_mask[:, None] & pos_mask[None, :],
+                other=0.0,
+            )
+            if USE_FP8:
+                k = k.to(q.dtype)
+                if KV_SCALE_MODE == 1:
+                    k = (k * tl.load(k_scale_ptr)).to(q.dtype)
+                elif KV_SCALE_MODE == 2:
+                    k_scale = tl.load(
+                        k_scale_ptr
+                        + pid_kh * stride_ks_h
+                        + (page * BLOCK_SIZE_K + off_n) * stride_ks_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+                    k = (k * k_scale[None, :]).to(q.dtype)
+            qk = tl.zeros((BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
+            # causal: q_abs_pos - k_off >= block_start (c)
+            qk += tl.where(off_q[:, None, :] >= c, 0, float("-inf"))
+            qk = tl.reshape(qk, BLOCK_SIZE_QH, BLOCK_SIZE_K)
+            qk += tl.dot(q, k) * sm_scale_log2e
+            qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+            p = tl.exp2(qk - m_ij[:, None])
+            l_ij = tl.sum(p, axis=1)
+            acc_o = acc_o * tl.exp2(m_i - m_ij)[:, None]
+            v = tl.load(
+                kv_cache_ptr
+                + page * stride_kv_blk
+                + pid_kh * stride_kv_h
+                + off_n[:, None] * stride_kv_pos
+                + (head_dim + off_d[None, :]) * stride_kv_d,
+                mask=pos_mask[:, None] & d_mask[None, :],
+                other=0.0,
+            )
+            if USE_FP8:
+                v = v.to(q.dtype)
+                if KV_SCALE_MODE == 1:
+                    v = (v * tl.load(v_scale_ptr)).to(q.dtype)
+                elif KV_SCALE_MODE == 2:
+                    v_scale = tl.load(
+                        v_scale_ptr
+                        + pid_kh * stride_vs_h
+                        + (page * BLOCK_SIZE_K + off_n) * stride_vs_t,
+                        mask=pos_mask,
+                        other=1.0,
+                    )
+                    v = (v * v_scale[:, None]).to(q.dtype)
+            acc_o += tl.dot(p.to(v.dtype), v)
+            m_i = m_ij
+            lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
+        acc_o = acc_o * tl.exp2(m_i - lse_i)[:, None]
+        acc_o = tl.reshape(acc_o, BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D)
+        o_ptrs = tl.make_block_ptr(
+            base=o_ptr + q_start * stride_on + pid_h * stride_oh,
+            shape=(q_len, gqa_group_size, head_dim),
+            strides=(stride_on, stride_oh, stride_od),
+            offsets=(pid_q_j * BLOCK_SIZE_Q, 0, 0),
+            block_shape=(BLOCK_SIZE_Q, BLOCK_SIZE_H, BLOCK_SIZE_D),
+            order=(2, 1, 0),
+        )
+        tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1, 2))
+
+
+# ---------------------------------------------------------------------------
+# Decode kernels (split-K). Decode batches are flattened request-major, with a
+# runtime query length used to map each query token back to its request metadata.
+# This parallelizes over the selected top-k blocks, producing partials that the
+# merge kernel combines (flash-decoding). All chunk counts depend only on shape
+# constants so the grid is fixed within a cuda graph. Base-2 (exp2/log2)
+# softmax matches the prefill kernel.
+# ---------------------------------------------------------------------------
+@triton.heuristics(
+    {
+        "BLOCK_SIZE_H": lambda args: max(
+            16, triton.next_power_of_2(args["gqa_group_size"])
+        ),
+        "BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"]),
+    }
+)
+@triton.jit(do_not_specialize=["decode_query_len"])
+def _gqa_sparse_decode_kernel(
+    q_ptr,  # [total_q, num_heads, head_dim]
+    kv_cache_ptr,  # main cache: [num_blocks, num_kv_heads, 128, 2*head_dim]
+    k_scale_ptr,
+    v_scale_ptr,
+    t_ptr,  # topk_idx: [num_kv_heads, total_q, topk]
+    o_ptr,  # partial out: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
+    lse_ptr,  # partial lse (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
+    block_table_ptr,  # [num_reqs, max_blocks]
+    seq_lens,  # [num_reqs]
+    total_q,
+    gqa_group_size,
+    head_dim,
+    max_topk,
+    sm_scale,
+    decode_query_len,
+    stride_qn,
+    stride_qh,
+    stride_qd,
+    stride_kv_blk,
+    stride_kv_h,
+    stride_kv_pos,
+    stride_kv_d,
+    stride_ks_h,
+    stride_ks_t,
+    stride_vs_h,
+    stride_vs_t,
+    stride_th,
+    stride_tn,
+    stride_tk,
+    stride_o_c,
+    stride_o_b,
+    stride_o_h,
+    stride_o_d,
+    stride_l_c,
+    stride_l_b,
+    stride_l_h,
+    stride_bt_b,
+    BLOCK_SIZE_K: tl.constexpr,  # == SPARSE_BLOCK_SIZE (128)
+    NUM_TOPK_CHUNKS: tl.constexpr,
+    BLOCK_SIZE_H: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    USE_FP8: tl.constexpr,  # fp8 KV cache: dequantize K/V to q.dtype on load
+    KV_SCALE_MODE: tl.constexpr,  # 0: none, 1: scalar, 2: [kv_head, token]
+    USE_PDL: tl.constexpr,
+):
+    sm_scale_log2e = sm_scale * 1.4426950409
+    # split-K over the topk dimension: pid(0) folds (query-token, chunk).
+    pid_bc, pid_kh = tl.program_id(0), tl.program_id(1)
+    pid_b = pid_bc % total_q
+    pid_c = pid_bc // total_q
+    req_id = pid_b // decode_query_len
+    q_offset = pid_b - req_id * decode_query_len
+    pid_h = pid_kh * gqa_group_size
+    chunk_size_topk = (max_topk + NUM_TOPK_CHUNKS - 1) // NUM_TOPK_CHUNKS
+    chunk_start_topk = pid_c * chunk_size_topk
+    chunk_end_compiletime = chunk_start_topk + chunk_size_topk
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+
+    seq_len = tl.load(seq_lens + req_id)
+    query_pos = seq_len - decode_query_len + q_offset
+    # Full-CG padding uses zero-length request rows. Clamp to an empty
+    # attention range instead of letting padded rows produce negative lengths.
+    kv_len = tl.maximum(query_pos + 1, 0)
+
+    # Valid block count from seq_len (no sentinel): min(topk, cdiv(kv_len, blk)).
+    idx_base = t_ptr + pid_kh * stride_th + pid_b * stride_tn
+    num_blocks = (kv_len + BLOCK_SIZE_K - 1) // BLOCK_SIZE_K
+    real_topk = tl.minimum(max_topk, num_blocks)
+    chunk_end_topk = tl.minimum(chunk_end_compiletime, real_topk)
+
+    off_n = tl.arange(0, BLOCK_SIZE_K)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    d_mask = off_d < head_dim
+    bt_row = block_table_ptr + req_id * stride_bt_b
+
+    m_i = tl.full((BLOCK_SIZE_H,), float("-inf"), dtype=tl.float32)
+    lse_i = tl.full((BLOCK_SIZE_H,), float("-inf"), dtype=tl.float32)
+    acc_o = tl.zeros((BLOCK_SIZE_H, BLOCK_SIZE_D), dtype=tl.float32)
+    q_ptrs = tl.make_block_ptr(
+        base=q_ptr + pid_b * stride_qn + pid_h * stride_qh,
+        shape=(gqa_group_size, head_dim),
+        strides=(stride_qh, stride_qd),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    q = tl.load(q_ptrs, boundary_check=(0, 1), padding_option="zero")
+
+    cur_idx_ptr = idx_base + chunk_start_topk * stride_tk
+    for _ in tl.range(chunk_start_topk, chunk_end_topk):
+        blk = tl.load(cur_idx_ptr).to(tl.int32)
+        cur_idx_ptr = cur_idx_ptr + stride_tk
+        c = blk * BLOCK_SIZE_K
+        page = tl.load(bt_row + blk).to(tl.int64)
+        pos = c + off_n
+        pos_mask = pos < kv_len
+        k = tl.load(
+            kv_cache_ptr
+            + page * stride_kv_blk
+            + pid_kh * stride_kv_h
+            + off_n[None, :] * stride_kv_pos
+            + off_d[:, None] * stride_kv_d,
+            mask=d_mask[:, None] & pos_mask[None, :],
+            other=0.0,
+        )
+        if USE_FP8:
+            k = k.to(q.dtype)
+            if KV_SCALE_MODE == 1:
+                k = (k * tl.load(k_scale_ptr)).to(q.dtype)
+            elif KV_SCALE_MODE == 2:
+                k_scale = tl.load(
+                    k_scale_ptr
+                    + pid_kh * stride_ks_h
+                    + (page * BLOCK_SIZE_K + off_n) * stride_ks_t,
+                    mask=pos_mask,
+                    other=1.0,
+                )
+                k = (k * k_scale[None, :]).to(q.dtype)
+        qk = tl.zeros((BLOCK_SIZE_H, BLOCK_SIZE_K), dtype=tl.float32)
+        qk += tl.where(pos_mask[None, :], 0, float("-inf"))
+        qk += tl.dot(q, k) * sm_scale_log2e
+        m_ij = tl.maximum(m_i, tl.max(qk, axis=1))
+        p = tl.exp2(qk - m_ij[:, None])
+        l_ij = tl.sum(p, axis=1)
+        acc_o = acc_o * tl.exp2(m_i - m_ij)[:, None]
+        v = tl.load(
+            kv_cache_ptr
+            + page * stride_kv_blk
+            + pid_kh * stride_kv_h
+            + off_n[:, None] * stride_kv_pos
+            + (head_dim + off_d[None, :]) * stride_kv_d,
+            mask=pos_mask[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+        if USE_FP8:
+            v = v.to(q.dtype)
+            if KV_SCALE_MODE == 1:
+                v = (v * tl.load(v_scale_ptr)).to(q.dtype)
+            elif KV_SCALE_MODE == 2:
+                v_scale = tl.load(
+                    v_scale_ptr
+                    + pid_kh * stride_vs_h
+                    + (page * BLOCK_SIZE_K + off_n) * stride_vs_t,
+                    mask=pos_mask,
+                    other=1.0,
+                )
+                v = (v * v_scale[:, None]).to(q.dtype)
+        acc_o += tl.dot(p.to(v.dtype), v)
+        m_i = m_ij
+        lse_i = m_ij + tl.log2(tl.exp2(lse_i - m_ij) + l_ij)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Empty chunks for active rows must store zero output; otherwise the merge
+    # can hit 0 * NaN. All-empty padded rows may still produce NaNs in merge.
+    scale = tl.where(lse_i > float("-inf"), tl.exp2(m_i - lse_i), tl.zeros_like(lse_i))
+    acc_o = acc_o * scale[:, None]
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + pid_c * stride_o_c + pid_b * stride_o_b + pid_h * stride_o_h,
+        shape=(gqa_group_size, head_dim),
+        strides=(stride_o_h, stride_o_d),
+        offsets=(0, 0),
+        block_shape=(BLOCK_SIZE_H, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    tl.store(o_ptrs, acc_o.to(o_ptr.dtype.element_ty), boundary_check=(0, 1))
+    lse_ptrs = tl.make_block_ptr(
+        base=lse_ptr + pid_c * stride_l_c + pid_b * stride_l_b + pid_h * stride_l_h,
+        shape=(gqa_group_size,),
+        strides=(stride_l_h,),
+        offsets=(0,),
+        block_shape=(BLOCK_SIZE_H,),
+        order=(0,),
+    )
+    tl.store(lse_ptrs, lse_i.to(lse_ptr.dtype.element_ty), boundary_check=(0,))
+
+
+@triton.heuristics(
+    {"BLOCK_SIZE_D": lambda args: triton.next_power_of_2(args["head_dim"])}
+)
+@triton.jit
+def _merge_topk_attn_out_kernel(
+    o_ptr,  # partials: [NUM_TOPK_CHUNKS, total_q, num_heads, head_dim]
+    lse_ptr,  # partials (log2): [NUM_TOPK_CHUNKS, total_q, num_heads]
+    out_ptr,  # merged out: [total_q, num_heads, head_dim]
+    head_dim,
+    stride_o_c,
+    stride_o_b,
+    stride_o_h,
+    stride_o_d,
+    stride_l_c,
+    stride_l_b,
+    stride_l_h,
+    stride_out_n,
+    stride_out_h,
+    stride_out_d,
+    NUM_TOPK_CHUNKS: tl.constexpr,
+    BLOCK_SIZE_D: tl.constexpr,
+    USE_PDL: tl.constexpr,
+):
+    pid_b, pid_h = tl.program_id(0), tl.program_id(1)
+
+    # NOTE: assume seq_lens is safe to load before gdc_wait()
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+        tl.extra.cuda.gdc_launch_dependents()
+
+    off_c = tl.arange(0, NUM_TOPK_CHUNKS)
+    off_d = tl.arange(0, BLOCK_SIZE_D)
+    o_ptrs = tl.make_block_ptr(
+        base=o_ptr + pid_b * stride_o_b + pid_h * stride_o_h,
+        shape=(NUM_TOPK_CHUNKS, head_dim),
+        strides=(stride_o_c, stride_o_d),
+        offsets=(0, 0),
+        block_shape=(NUM_TOPK_CHUNKS, BLOCK_SIZE_D),
+        order=(1, 0),
+    )
+    lse_ptrs = lse_ptr + pid_b * stride_l_b + pid_h * stride_l_h + off_c * stride_l_c
+    o = tl.load(o_ptrs, boundary_check=(0, 1), padding_option="zero")
+    lse = tl.load(lse_ptrs)  # empty chunks contribute -inf -> weight 0
+    lse_max = tl.max(lse, axis=0)
+    weights = tl.exp2(lse - lse_max)
+    weights = weights / tl.sum(weights, axis=0)
+    o_merged = tl.sum(o * weights[:, None], axis=0)
+    out_ptrs = (
+        out_ptr + pid_b * stride_out_n + pid_h * stride_out_h + off_d * stride_out_d
+    )
+    tl.store(out_ptrs, o_merged.to(out_ptr.dtype.element_ty), mask=off_d < head_dim)
+
+
+# ---------------------------------------------------------------------------
+# Python wrappers
+# ---------------------------------------------------------------------------
+_KV_SCALE_NONE = 0
+_KV_SCALE_SCALAR = 1
+_KV_SCALE_PER_TOKEN_HEAD = 2
+
+
+def _kv_scale_args(
+    output: torch.Tensor,
+    num_kv_heads: int,
+    k_scale: torch.Tensor | None,
+    v_scale: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor, int, int, int, int, int]:
+    if k_scale is None and v_scale is None:
+        return output, output, 0, 0, 0, 0, _KV_SCALE_NONE
+    if k_scale is None or v_scale is None:
+        raise ValueError("k_scale and v_scale must be both provided or both None")
+    if k_scale.device != output.device or v_scale.device != output.device:
+        raise ValueError("k_scale and v_scale must be on the same device as output")
+    if k_scale.numel() == 1 and v_scale.numel() == 1:
+        return k_scale, v_scale, 0, 0, 0, 0, _KV_SCALE_SCALAR
+    if k_scale.dim() == 2 and v_scale.dim() == 2:
+        if k_scale.shape[0] != num_kv_heads or v_scale.shape[0] != num_kv_heads:
+            raise ValueError(
+                "per-token/head KV scales must have shape "
+                f"[{num_kv_heads}, max_kv_tokens]"
+            )
+        if k_scale.shape != v_scale.shape:
+            raise ValueError("k_scale and v_scale must have matching shapes")
+        return (
+            k_scale,
+            v_scale,
+            k_scale.stride(0),
+            k_scale.stride(1),
+            v_scale.stride(0),
+            v_scale.stride(1),
+            _KV_SCALE_PER_TOKEN_HEAD,
+        )
+    raise ValueError(
+        "MiniMax-M3 sparse attention supports scalar KV scales or "
+        "[num_kv_heads, max_kv_tokens] per-token/head scales"
+    )
+
+
+@torch.no_grad()
+def minimax_m3_sparse_attn(
+    q: torch.Tensor,  # [total_q, num_heads, head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    topk_idx: torch.Tensor,  # [num_kv_heads, total_q, topk]
+    block_table: torch.Tensor,  # [batch, max_blocks]
+    cu_seqlens_q: torch.Tensor,  # [batch+1] int32
+    seq_lens: torch.Tensor,  # [batch] int32
+    prefix_lens: torch.Tensor,  # [batch] int32
+    max_query_len: int,
+    num_kv_heads: int,
+    sm_scale: float,
+    output: torch.Tensor,  # [total_q, num_heads, head_dim]
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
+) -> None:
+    """GQA block-sparse attention over the selected blocks. block_size_q == 1."""
+    total_q, num_heads, head_dim = q.shape
+    batch = cu_seqlens_q.shape[0] - 1
+    topk = topk_idx.shape[-1]
+    gqa_group_size = num_heads // num_kv_heads
+    use_fp8 = kv_cache.dtype in _FP8_DTYPES
+    (
+        k_scale_arg,
+        v_scale_arg,
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        kv_scale_mode,
+    ) = (
+        _kv_scale_args(output, num_kv_heads, k_scale, v_scale)
+        if use_fp8
+        else (
+            output,
+            output,
+            0,
+            0,
+            0,
+            0,
+            _KV_SCALE_NONE,
+        )
+    )
+    grid = (max_query_len, num_kv_heads, batch)
+    _gqa_sparse_fwd_kernel[grid](
+        q,
+        kv_cache,
+        k_scale_arg,
+        v_scale_arg,
+        topk_idx,
+        output,
+        block_table,
+        cu_seqlens_q,
+        cu_seqlens_q,  # cu_seqblocks_q == cu_seqlens_q when block_size_q == 1
+        seq_lens,
+        prefix_lens,
+        num_kv_heads,
+        gqa_group_size,
+        head_dim,
+        topk,
+        1,  # num_q_loop
+        sm_scale,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_Q=1,
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        USE_FP8=use_fp8,
+        KV_SCALE_MODE=kv_scale_mode,
+    )
+
+
+@torch.no_grad()
+def minimax_m3_sparse_attn_decode(
+    q: torch.Tensor,  # [total_q, num_heads, head_dim]
+    kv_cache: torch.Tensor,  # [num_blocks, num_kv_heads, 128, 2*head_dim]
+    topk_idx: torch.Tensor,  # [num_kv_heads, total_q, topk]
+    block_table: torch.Tensor,  # [num_reqs, max_blocks]
+    seq_lens: torch.Tensor,  # [num_reqs] int32
+    num_kv_heads: int,
+    sm_scale: float,
+    output: torch.Tensor,  # [total_q, num_heads, head_dim]
+    decode_query_len: int,
+    k_scale: torch.Tensor | None = None,
+    v_scale: torch.Tensor | None = None,
+) -> None:
+    """GQA block-sparse attention for decode (split-K over the top-k blocks)."""
+    total_q, num_heads, head_dim = q.shape
+    assert total_q == seq_lens.shape[0] * decode_query_len
+    max_topk = topk_idx.shape[-1]
+    gqa_group_size = num_heads // num_kv_heads
+    use_fp8 = kv_cache.dtype in _FP8_DTYPES
+    (
+        k_scale_arg,
+        v_scale_arg,
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        kv_scale_mode,
+    ) = (
+        _kv_scale_args(output, num_kv_heads, k_scale, v_scale)
+        if use_fp8
+        else (
+            output,
+            output,
+            0,
+            0,
+            0,
+            0,
+            _KV_SCALE_NONE,
+        )
+    )
+    use_pdl = current_platform.is_arch_support_pdl()
+    # `launch_pdl` is a Triton runtime kwarg only some backends accept (CUDA
+    # SM9+); this ROCm Triton rejects it even when False ("Keyword argument
+    # launch_pdl was specified but unrecognised"). Only pass it when PDL is
+    # actually supported -- on ROCm use_pdl is always False, so it's omitted.
+    pdl_launch = {"launch_pdl": True} if use_pdl else {}
+    # split-K over the selected blocks; chunk count is shape-constant (cuda graph).
+    TARGET_GRID = 256
+    target = max(1, min(max_topk, TARGET_GRID // max(1, total_q * num_kv_heads)))
+    num_topk_chunks = 1 << (target.bit_length() - 1)
+    o_partial = torch.empty(
+        num_topk_chunks, total_q, num_heads, head_dim, dtype=q.dtype, device=q.device
+    )
+    lse_partial = torch.empty(
+        num_topk_chunks, total_q, num_heads, dtype=torch.float32, device=q.device
+    )
+    grid = (total_q * num_topk_chunks, num_kv_heads)
+    _gqa_sparse_decode_kernel[grid](
+        q,
+        kv_cache,
+        k_scale_arg,
+        v_scale_arg,
+        topk_idx,
+        o_partial,
+        lse_partial,
+        block_table,
+        seq_lens,
+        total_q,
+        gqa_group_size,
+        head_dim,
+        max_topk,
+        sm_scale,
+        decode_query_len,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        kv_cache.stride(0),
+        kv_cache.stride(1),
+        kv_cache.stride(2),
+        kv_cache.stride(3),
+        stride_ks_h,
+        stride_ks_t,
+        stride_vs_h,
+        stride_vs_t,
+        topk_idx.stride(0),
+        topk_idx.stride(1),
+        topk_idx.stride(2),
+        o_partial.stride(0),
+        o_partial.stride(1),
+        o_partial.stride(2),
+        o_partial.stride(3),
+        lse_partial.stride(0),
+        lse_partial.stride(1),
+        lse_partial.stride(2),
+        block_table.stride(0),
+        BLOCK_SIZE_K=SPARSE_BLOCK_SIZE,
+        NUM_TOPK_CHUNKS=num_topk_chunks,
+        USE_FP8=use_fp8,
+        KV_SCALE_MODE=kv_scale_mode,
+        USE_PDL=use_pdl,
+        **pdl_launch,
+    )
+    merge_grid = (total_q, num_heads)
+    _merge_topk_attn_out_kernel[merge_grid](
+        o_partial,
+        lse_partial,
+        output,
+        head_dim,
+        o_partial.stride(0),
+        o_partial.stride(1),
+        o_partial.stride(2),
+        o_partial.stride(3),
+        lse_partial.stride(0),
+        lse_partial.stride(1),
+        lse_partial.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_TOPK_CHUNKS=num_topk_chunks,
+        USE_PDL=use_pdl,
+        **pdl_launch,
+    )

--- a/src/flag_attn/minimax_sparse_attention/utils.py
+++ b/src/flag_attn/minimax_sparse_attention/utils.py
@@ -1,0 +1,43 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions extracted from vLLM framework dependencies."""
+
+import torch
+
+
+class _CurrentPlatform:
+    """Small platform adapter used by the MSA Triton kernels."""
+
+    def is_arch_support_pdl(self) -> bool:
+        if not torch.cuda.is_available():
+            return False
+        # HIP/ROCm does not accept CUDA's launch_pdl runtime argument.
+        if torch.version.hip is not None:
+            return False
+        try:
+            capability = torch.cuda.get_device_capability()
+        except RuntimeError:
+            return False
+        # PDL is enabled only for CUDA devices with the required capability.
+        return capability >= (9, 0)
+
+
+current_platform = _CurrentPlatform()
+
+
+def round_up(n: int, d: int) -> int:
+    """Round n up to the nearest multiple of d."""
+    return (n + d - 1) // d * d

--- a/src/flag_attn/minimax_sparse_attention/utils.py
+++ b/src/flag_attn/minimax_sparse_attention/utils.py
@@ -1,3 +1,18 @@
+# Copyright 2026 FlagOS Contributors
+# Copyright contributors to the vLLM project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Utility functions extracted from vLLM framework dependencies."""
 
 import re

--- a/src/flag_attn/minimax_sparse_attention/utils.py
+++ b/src/flag_attn/minimax_sparse_attention/utils.py
@@ -1,19 +1,6 @@
-# Copyright 2026 FlagOS Contributors
-# Copyright contributors to the vLLM project
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """Utility functions extracted from vLLM framework dependencies."""
+
+import re
 
 import torch
 
@@ -41,3 +28,16 @@ current_platform = _CurrentPlatform()
 def round_up(n: int, d: int) -> int:
     """Round n up to the nearest multiple of d."""
     return (n + d - 1) // d * d
+
+
+def has_triton_tle(major: int = 0, minor: int = 0, patch: int = 0) -> bool:
+    """Return whether the installed Triton exposes the TLE language module."""
+    try:
+        import triton
+        import triton.experimental.tle.language as _tle  # noqa: F401
+    except ImportError:
+        return False
+    version = str(getattr(triton, "__version__", "0.0.0"))
+    release = [int(value) for value in re.findall(r"\d+", version)[:3]]
+    release += [0] * (3 - len(release))
+    return tuple(release[:3]) >= (major, minor, patch)

--- a/tests/flag_attn/test_chunk_gla.py
+++ b/tests/flag_attn/test_chunk_gla.py
@@ -1,0 +1,1120 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Self-contained fused_recurrent_gla implementation
+# Inlined from:
+#   fla/ops/gla/fused_recurrent.py
+#   fla/ops/common/fused_recurrent.py
+#   fla/ops/utils/op.py (exp only)
+#   fla/utils.py (autocast, input_guard, autotune_cache_kwargs)
+
+import contextlib
+import functools
+import inspect
+import inspect as _inspect
+import os
+import os as _os
+
+import pytest
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+from flag_attn.gated_linear_attention import chunk_gla
+from flag_attn.gated_linear_attention.index import (
+    prepare_chunk_indices as _prepare_chunk_indices,
+)
+
+
+# --- From fla/ops/utils/op.py: exp ---
+@triton.jit
+def exp(x):
+    return tl.exp(x.to(tl.float32))
+
+
+# --- From fla/utils.py: autotune_cache_kwargs ---
+if "cache_results" in _inspect.signature(triton.autotune).parameters:
+    _autotune_cache_kwargs = {
+        "cache_results": _os.getenv("FLA_CACHE_RESULTS", "1") == "1"
+    }
+else:
+    _autotune_cache_kwargs = {}
+
+# --- From fla/utils.py: autocast helpers ---
+_autocast_custom_fwd = torch.amp.custom_fwd(device_type="cuda")
+_autocast_custom_bwd = torch.amp.custom_bwd(device_type="cuda")
+
+
+# --- From fla/utils.py: input_guard (minimal) ---
+def _input_guard(fn=None, *, no_guard_contiguous=False):
+    def _decorator(fn):
+        sig = _inspect.signature(fn)
+        param_names = list(sig.parameters.keys())
+        skip_params = set()
+        if isinstance(no_guard_contiguous, list):
+            skip_params = set(no_guard_contiguous)
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            processed_args = []
+            for i, arg in enumerate(args):
+                if i < len(param_names):
+                    pname = param_names[i]
+                else:
+                    pname = "__arg_{}".format(i)
+                if isinstance(arg, torch.Tensor):
+                    if no_guard_contiguous is True or pname in skip_params:
+                        processed_args.append(arg)
+                    else:
+                        processed_args.append(arg.contiguous())
+                else:
+                    processed_args.append(arg)
+
+            processed_kwargs = {}
+            for k, v in kwargs.items():
+                if isinstance(v, torch.Tensor):
+                    if no_guard_contiguous is True or k in skip_params:
+                        processed_kwargs[k] = v
+                    else:
+                        processed_kwargs[k] = v.contiguous()
+                else:
+                    processed_kwargs[k] = v
+
+            tensor = None
+            for arg in args:
+                if isinstance(arg, torch.Tensor):
+                    tensor = arg
+                    break
+            if tensor is None:
+                for v in kwargs.values():
+                    if isinstance(v, torch.Tensor):
+                        tensor = v
+                        break
+
+            if tensor is not None and tensor.device.type == "cuda":
+                ctx = torch.cuda.device(tensor.device.index)
+            else:
+                ctx = contextlib.nullcontext()
+            with ctx:
+                return fn(*processed_args, **processed_kwargs)
+
+        return wrapper
+
+    if fn is not None:
+        return _decorator(fn)
+    return _decorator
+
+
+# --- From fla/ops/common/fused_recurrent.py: fwd kernel ---
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [4, 8]],
+    key=["BK", "BV", "USE_G", "USE_G_GAMMA", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+    **_autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def _fused_recurrent_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    o,
+    h0,
+    ht,
+    cu_seqlens,
+    scale,
+    B,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    REVERSE: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr = False,
+):
+    i_v, i_k, i_nh = (
+        tl.program_id(0).to(tl.int64),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_n, i_h = i_nh // H, i_nh % H
+
+    all = B * T
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    p_q = q + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_k = k + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_o = o + ((i_k * all + bos) + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if REVERSE else 0)) * H + i_h
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    if USE_GV:
+        p_gv = gv + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
+
+    m_k = o_k < K
+    m_v = o_v < V
+    if STATE_V_FIRST:
+        m_h = m_v[:, None] & m_k[None, :]
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        b_q = tl.load(p_q, mask=m_k, other=0).to(tl.float32) * scale
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
+        if USE_GV:
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if STATE_V_FIRST:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_o = tl.sum(b_h * b_q[None, :], axis=1)
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_q[:, None], axis=0)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=m_v)
+        p_q += (-1 if REVERSE else 1) * H * K
+        p_k += (-1 if REVERSE else 1) * H * K
+        p_v += (-1 if REVERSE else 1) * H * V
+        p_o += (-1 if REVERSE else 1) * H * V
+        if USE_G:
+            p_g += (-1 if REVERSE else 1) * H
+        if USE_GK:
+            p_gk += (-1 if REVERSE else 1) * H * K
+        if USE_GV:
+            p_gv += (-1 if REVERSE else 1) * H * V
+
+    if STORE_FINAL_STATE:
+        if STATE_V_FIRST:
+            p_ht = ht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_ht = ht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=m_h)
+
+
+# --- From fla/ops/common/fused_recurrent.py: bwd kernel ---
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_INITIAL_STATE_GRADIENT": lambda args: args["dh0"] is not None,
+        "USE_FINAL_STATE_GRADIENT": lambda args: args["dht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [4]],
+    key=["BK", "BV", "USE_G", "USE_G_GAMMA", "USE_GK", "USE_GV", "STATE_V_FIRST"],
+    **_autotune_cache_kwargs,
+)
+@triton.jit(do_not_specialize=["B", "T"])
+def _fused_recurrent_bwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    g_gamma,
+    gk,
+    gv,
+    o,
+    h0,
+    do,
+    dq,
+    dk,
+    dv,
+    dg,
+    dgk,
+    dgv,
+    dht,
+    dh0,
+    cu_seqlens,
+    scale,
+    B,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    REVERSE: tl.constexpr,
+    USE_G: tl.constexpr,
+    USE_G_GAMMA: tl.constexpr,
+    USE_GK: tl.constexpr,
+    USE_GV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_INITIAL_STATE_GRADIENT: tl.constexpr,
+    USE_FINAL_STATE_GRADIENT: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    STATE_V_FIRST: tl.constexpr = False,
+):
+    i_v, i_k, i_nh = (
+        tl.program_id(0).to(tl.int64),
+        tl.program_id(1).to(tl.int64),
+        tl.program_id(2).to(tl.int64),
+    )
+    i_n, i_h = i_nh // H, i_nh % H
+
+    all = B * T
+    if IS_VARLEN:
+        bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
+            cu_seqlens + i_n + 1
+        ).to(tl.int64)
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+    NV = tl.cdiv(V, BV)
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    m_k = o_k < K
+    m_v = o_v < V
+    if STATE_V_FIRST:
+        m_h = m_v[:, None] & m_k[None, :]
+    else:
+        m_h = m_k[:, None] & m_v[None, :]
+
+    p_k = k + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_do = do + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_dq = (
+        dq + ((i_v * all + bos) + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    )
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if REVERSE else 0)) * H + i_h
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    if USE_GV:
+        p_gv = gv + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    if USE_G_GAMMA:
+        b_g_gamma = tl.load(g_gamma + i_h)
+
+    if STATE_V_FIRST:
+        b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if STATE_V_FIRST:
+            p_h0 = h0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_h += tl.load(p_h0, mask=m_h, other=0).to(tl.float32)
+
+    for _ in range(0, T):
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        b_do = tl.load(p_do, mask=m_v, other=0).to(tl.float32)
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h = b_h * exp(b_g)
+        if USE_G_GAMMA:
+            b_h = b_h * exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gk[None, :])
+            else:
+                b_h = b_h * exp(b_gk[:, None])
+        if USE_GV:
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if STATE_V_FIRST:
+                b_h = b_h * exp(b_gv[:, None])
+            else:
+                b_h = b_h * exp(b_gv[None, :])
+        if STATE_V_FIRST:
+            b_h += b_v[:, None] * b_k[None, :]
+            b_dq = tl.sum(b_h * b_do[:, None], axis=0) * scale
+        else:
+            b_h += b_k[:, None] * b_v[None, :]
+            b_dq = tl.sum(b_h * b_do[None, :], axis=1) * scale
+        tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), mask=m_k)
+
+        p_k += (-1 if REVERSE else 1) * H * K
+        p_v += (-1 if REVERSE else 1) * H * V
+        p_do += (-1 if REVERSE else 1) * H * V
+        p_dq += (-1 if REVERSE else 1) * H * K
+        if USE_G:
+            p_g += (-1 if REVERSE else 1) * H
+        if USE_GK:
+            p_gk += (-1 if REVERSE else 1) * H * K
+        if USE_GV:
+            p_gv += (-1 if REVERSE else 1) * H * V
+
+    # sync threads
+    tl.debug_barrier()
+
+    p_q = q + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+    p_k = k + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+
+    p_do = do + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+    p_dq = (
+        dq
+        + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+        + i_h * K
+        + o_k
+    )
+    p_dk = (
+        dk
+        + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+        + i_h * K
+        + o_k
+    )
+    p_dv = (
+        dv
+        + ((i_k * all + bos) + ((T - 1) if not REVERSE else 0)) * H * V
+        + i_h * V
+        + o_v
+    )
+    if USE_G:
+        p_g = g + (bos + ((T - 1) if not REVERSE else 0)) * H + i_h
+        p_dg = (
+            dg
+            + ((i_k * NV + i_v) * all + bos + ((T - 1) if not REVERSE else 0)) * H
+            + i_h
+        )
+    if USE_GK:
+        p_gk = gk + (bos + ((T - 1) if not REVERSE else 0)) * H * K + i_h * K + o_k
+        p_dgk = (
+            dgk
+            + ((i_v * all + bos) + ((T - 1) if not REVERSE else 0)) * H * K
+            + i_h * K
+            + o_k
+        )
+    if USE_GV:
+        p_o = o + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+        p_gv = gv + (bos + ((T - 1) if not REVERSE else 0)) * H * V + i_h * V + o_v
+        p_dgv = (
+            dgv
+            + ((i_k * all + bos) + ((T - 1) if not REVERSE else 0)) * H * V
+            + i_h * V
+            + o_v
+        )
+
+    if STATE_V_FIRST:
+        b_dh = tl.zeros([BV, BK], dtype=tl.float32)
+    else:
+        b_dh = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_FINAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dht = dht + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dht = dht + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        b_dh += tl.load(p_dht, mask=m_h, other=0).to(tl.float32)
+
+    if USE_G:
+        b_dg = tl.sum(b_h * b_dh)
+    if USE_GK:
+        if STATE_V_FIRST:
+            b_dgk = tl.sum(b_h * b_dh, 0)
+        else:
+            b_dgk = tl.sum(b_h * b_dh, 1)
+    if USE_GV:
+        if STATE_V_FIRST:
+            b_dgv = tl.sum(b_h * b_dh, 1)
+        else:
+            b_dgv = tl.sum(b_h * b_dh, 0)
+
+    for _ in range(T):
+        b_q = tl.load(p_q, mask=m_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=m_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=m_v, other=0).to(tl.float32)
+        b_do = tl.load(p_do, mask=m_v, other=0).to(tl.float32)
+        if STATE_V_FIRST:
+            b_dh += b_do[:, None] * (b_q * scale)[None, :]
+            b_dk = tl.sum(b_dh * b_v[:, None], axis=0)
+            b_dv = tl.sum(b_dh * b_k[None, :], axis=1)
+        else:
+            b_dh += (b_q * scale)[:, None] * b_do[None, :]
+            b_dk = tl.sum(b_dh * b_v[None, :], axis=1)
+            b_dv = tl.sum(b_dh * b_k[:, None], axis=0)
+
+        if USE_G:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_dq = tl.load(p_dq, mask=m_k, other=0).to(tl.float32)
+            b_dg += tl.sum(b_q * b_dq - b_k * b_dk)
+            b_dh *= exp(b_g)
+            tl.store(p_dg, b_dg.to(p_dg.dtype.element_ty))
+        if USE_G_GAMMA:
+            b_dh *= exp(b_g_gamma)
+        if USE_GK:
+            b_gk = tl.load(p_gk, mask=m_k, other=0).to(tl.float32)
+            b_dq = tl.load(p_dq, mask=m_k, other=0).to(tl.float32)
+            b_dgk += b_q * b_dq - b_k * b_dk
+            if STATE_V_FIRST:
+                b_dh *= exp(b_gk)[None, :]
+            else:
+                b_dh *= exp(b_gk)[:, None]
+            tl.store(p_dgk, b_dgk.to(p_dgk.dtype.element_ty), mask=m_k)
+        if USE_GV:
+            b_o = tl.load(p_o, mask=m_v, other=0).to(tl.float32)
+            b_gv = tl.load(p_gv, mask=m_v, other=0).to(tl.float32)
+            if i_k == 0:
+                b_dgv += b_o * b_do
+            b_dgv -= b_v * b_dv
+            if STATE_V_FIRST:
+                b_dh *= exp(b_gv)[:, None]
+            else:
+                b_dh *= exp(b_gv)[None, :]
+            tl.store(p_dgv, b_dgv.to(p_dgv.dtype.element_ty), mask=m_v)
+
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), mask=m_k)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), mask=m_v)
+
+        p_q += (1 if REVERSE else -1) * H * K
+        p_k += (1 if REVERSE else -1) * H * K
+        p_v += (1 if REVERSE else -1) * H * V
+
+        p_do += (1 if REVERSE else -1) * H * V
+        p_dq += (1 if REVERSE else -1) * H * K
+        p_dk += (1 if REVERSE else -1) * H * K
+        p_dv += (1 if REVERSE else -1) * H * V
+        if USE_G:
+            p_g += (1 if REVERSE else -1) * H
+            p_dg += (1 if REVERSE else -1) * H
+        if USE_GK:
+            p_gk += (1 if REVERSE else -1) * H * K
+            p_dgk += (1 if REVERSE else -1) * H * K
+        if USE_GV:
+            p_o += (1 if REVERSE else -1) * H * V
+            p_gv += (1 if REVERSE else -1) * H * V
+            p_dgv += (1 if REVERSE else -1) * H * V
+
+    if STORE_INITIAL_STATE_GRADIENT:
+        if STATE_V_FIRST:
+            p_dh0 = dh0 + i_nh * K * V + o_v[:, None] * K + o_k[None, :]
+        else:
+            p_dh0 = dh0 + i_nh * K * V + o_k[:, None] * V + o_v[None, :]
+        tl.store(p_dh0, b_dh.to(p_dh0.dtype.element_ty), mask=m_h)
+
+
+# --- From fla/ops/common/fused_recurrent.py: Python wrappers ---
+
+
+def _fused_recurrent_fwd(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK, BV = min(triton.next_power_of_2(K), 64), min(triton.next_power_of_2(V), 64)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+
+    h0 = initial_state
+    if output_final_state:
+        if state_v_first:
+            ht = q.new_empty(N, H, V, K, dtype=torch.float32)
+        else:
+            ht = q.new_empty(N, H, K, V, dtype=torch.float32)
+    else:
+        ht = None
+    o = q.new_empty(NK, *v.shape, dtype=torch.float32)
+
+    grid = (NV, NK, N * H)
+    _fused_recurrent_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        o=o,
+        h0=h0,
+        ht=ht,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        T=T,
+        B=B,
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        REVERSE=reverse,
+        STATE_V_FIRST=state_v_first,
+    )
+    o = o.sum(0)
+    return o, ht
+
+
+def _fused_recurrent_bwd(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    o=None,
+    do=None,
+    dht=None,
+    scale=None,
+    initial_state=None,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+
+    BK, BV = min(triton.next_power_of_2(K), 64), min(triton.next_power_of_2(V), 64)
+    NK, NV = triton.cdiv(K, BK), triton.cdiv(V, BV)
+
+    h0 = initial_state
+    dq = q.new_empty(NV, *q.shape, dtype=torch.float32)
+    dk = q.new_empty(NV, *k.shape, dtype=torch.float32)
+    dv = q.new_empty(NK, *v.shape, dtype=torch.float32)
+    dh0 = torch.empty_like(h0) if h0 is not None else None
+
+    dg, dgk, dgv = None, None, None
+    if g is not None:
+        dg = g.new_empty(NK * NV, *g.shape, dtype=torch.float32)
+    if gk is not None:
+        dgk = gk.new_empty(NV, *gk.shape, dtype=torch.float32)
+    if gv is not None:
+        dgv = gv.new_empty(NK, *gv.shape, dtype=torch.float32)
+
+    grid = (NV, NK, N * H)
+    _fused_recurrent_bwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        g_gamma=g_gamma,
+        gk=gk,
+        gv=gv,
+        o=o,
+        h0=h0,
+        do=do,
+        dq=dq,
+        dk=dk,
+        dv=dv,
+        dg=dg,
+        dgk=dgk,
+        dgv=dgv,
+        dht=dht,
+        dh0=dh0,
+        cu_seqlens=cu_seqlens,
+        scale=scale,
+        B=B,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        BV=BV,
+        USE_G=g is not None,
+        USE_G_GAMMA=g_gamma is not None,
+        USE_GK=gk is not None,
+        USE_GV=gv is not None,
+        REVERSE=reverse,
+        STATE_V_FIRST=state_v_first,
+    )
+    dq = dq.sum(0)
+    dk = dk.sum(0)
+    dv = dv.sum(0)
+    if g is not None:
+        dg = dg.sum(0).to(g)
+    if gk is not None:
+        dgk = dgk.sum(0).to(gk)
+    if gv is not None:
+        dgv = dgv.sum(0).to(gv)
+
+    return dq, dk, dv, dg, dgk, dgv, dh0
+
+
+# --- From fla/ops/common/fused_recurrent.py: autograd Function ---
+class _FusedRecurrentFunction(torch.autograd.Function):
+
+    @staticmethod
+    @_input_guard
+    @_autocast_custom_fwd
+    def forward(
+        ctx,
+        q,
+        k,
+        v,
+        g=None,
+        g_gamma=None,
+        gk=None,
+        gv=None,
+        scale=None,
+        initial_state=None,
+        output_final_state=False,
+        reverse=False,
+        state_v_first=False,
+        cu_seqlens=None,
+    ):
+        o, ht = _fused_recurrent_fwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_gamma=g_gamma,
+            gk=gk,
+            gv=gv,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            reverse=reverse,
+            cu_seqlens=cu_seqlens,
+            state_v_first=state_v_first,
+        )
+        ctx.save_for_backward(q, k, v, g, g_gamma, gk, gv, initial_state, o)
+        ctx.scale = scale
+        ctx.reverse = reverse
+        ctx.cu_seqlens = cu_seqlens
+        ctx.state_v_first = state_v_first
+        return o.to(q.dtype), ht
+
+    @staticmethod
+    @_input_guard
+    @_autocast_custom_bwd
+    def backward(ctx, do, dht):
+        q, k, v, g, g_gamma, gk, gv, initial_state, o = ctx.saved_tensors
+        dq, dk, dv, dg, dgk, dgv, dh0 = _fused_recurrent_bwd(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            g_gamma=g_gamma,
+            gk=gk,
+            gv=gv,
+            o=o,
+            do=do,
+            dht=dht,
+            scale=ctx.scale,
+            initial_state=initial_state,
+            reverse=ctx.reverse,
+            cu_seqlens=ctx.cu_seqlens,
+            state_v_first=ctx.state_v_first,
+        )
+        return (
+            dq.to(q.dtype),
+            dk.to(k.dtype),
+            dv.to(v.dtype),
+            dg,
+            None,
+            dgk,
+            dgv,
+            None,
+            dh0,
+            None,
+            None,
+            None,
+            None,
+        )
+
+
+# --- From fla/ops/common/fused_recurrent.py: fused_recurrent ---
+
+
+def _fused_recurrent(
+    q,
+    k,
+    v,
+    g=None,
+    g_gamma=None,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+):
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    return _FusedRecurrentFunction.apply(
+        q,
+        k,
+        v,
+        g,
+        g_gamma,
+        gk,
+        gv,
+        scale,
+        initial_state,
+        output_final_state,
+        reverse,
+        state_v_first,
+        cu_seqlens,
+    )
+
+
+# --- From fla/ops/gla/fused_recurrent.py: fused_recurrent_gla ---
+
+
+def fused_recurrent_gla(
+    q,
+    k,
+    v,
+    gk=None,
+    gv=None,
+    scale=None,
+    initial_state=None,
+    output_final_state=False,
+    reverse=False,
+    state_v_first=False,
+    cu_seqlens=None,
+    **kwargs,
+):
+    if "transpose_state_layout" in kwargs:
+        if state_v_first:
+            raise ValueError(
+                "Cannot pass both state_v_first and the deprecated transpose_state_layout."
+            )
+        import warnings as _w
+
+        _w.warn(
+            "transpose_state_layout is deprecated and renamed to state_v_first.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        state_v_first = kwargs.pop("transpose_state_layout")
+
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                "The batch size is expected to be 1 rather than {} when using cu_seqlens."
+                "Please flatten variable-length inputs before processing.".format(
+                    q.shape[0]
+                ),
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                "The number of initial states is expected to be equal to the number of input sequences, "
+                "i.e., {} rather than {}.".format(
+                    len(cu_seqlens) - 1, initial_state.shape[0]
+                ),
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    o, final_state = _fused_recurrent(
+        q=q,
+        k=k,
+        v=v,
+        g=None,
+        g_gamma=None,
+        gk=gk,
+        gv=gv,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        reverse=reverse,
+        cu_seqlens=cu_seqlens,
+        state_v_first=state_v_first,
+    )
+    return o, final_state
+
+
+def _cuda_available() -> bool:
+    return torch.cuda.is_available()
+
+
+pytestmark = [
+    pytest.mark.skipif(not _cuda_available(), reason="CUDA required"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _compat_prepare_chunk_indices_kwarg():
+    sig = inspect.signature(_prepare_chunk_indices)
+    if "cu_seqlens_cpu" in sig.parameters:
+        yield
+        return
+    import sys
+
+    mod = sys.modules["flag_attn.gated_linear_attention.chunk_gla"]
+    old = mod.prepare_chunk_indices
+
+    def _wrapped(cu_seqlens, chunk_size, cu_seqlens_cpu=None):
+        del cu_seqlens_cpu
+        return _prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    mod.prepare_chunk_indices = _wrapped
+    try:
+        yield
+    finally:
+        mod.prepare_chunk_indices = old
+
+
+def _assert_close(name, actual, expected, ratio, err_atol=1e-6):
+    abs_atol = (actual.detach() - expected.detach()).flatten().abs().max().item()
+    error_rate = (
+        (actual.detach() - expected.detach()).flatten().square().mean().sqrt()
+        / actual.detach().flatten().square().mean().sqrt().clamp_min(1e-8)
+    ).item()
+    print(f"[{name}] diff: {abs_atol:.6f} ratio: {error_rate:.6f}")
+    if abs_atol <= err_atol:
+        return
+    assert not torch.isnan(actual).any(), f"{name}: NaN detected in actual"
+    assert not torch.isnan(expected).any(), f"{name}: NaN detected in expected"
+    assert error_rate < ratio, f"{name}: diff: {abs_atol:.6f} ratio: {error_rate:.6f}"
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "gate_logit_normalizer", "dtype"),
+    [
+        pytest.param(*c, id="B{}-T{}-H{}-D{}-gate_logit_normalizer{}-{}".format(*c))
+        for c in [
+            (1, 63, 1, 64, 1.0, torch.float16),
+            (2, 1024, 4, 60, 1.0, torch.float16),
+            (2, 1024, 8, 128, 0.1, torch.float16),
+            (2, 1024, 8, 128, 1.0, torch.float16),
+            (2, 1024, 8, 128, 10.0, torch.float16),
+            (4, 2048, 8, 64, 1.0, torch.float16),
+        ]
+    ],
+)
+def test_chunk(B, T, H, D, dtype, gate_logit_normalizer):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = torch.device("cuda")
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device).requires_grad_()
+    g = (
+        F.logsigmoid(torch.rand(B, T, H, D, dtype=dtype, device=device))
+        / gate_logit_normalizer
+    ).requires_grad_()
+    h0 = torch.rand(B, H, D, D, dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+    dht = torch.randn(B, H, D, D, dtype=torch.float32, device=device)
+
+    tri, tri_ht = chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=D**-0.5,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=None,
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum().to(do.dtype)).backward()
+    tri_dq, tri_dk, tri_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    tri_dg, tri_dh0 = g.grad.clone(), h0.grad.clone()
+    q.grad = k.grad = v.grad = g.grad = h0.grad = None
+
+    ref, ref_ht = fused_recurrent_gla(
+        q=q,
+        k=k,
+        v=v,
+        gk=g,
+        initial_state=h0,
+        output_final_state=True,
+    )
+    ((ref * do).sum() + (ref_ht * dht).sum()).backward()
+    ref_dq, ref_dk, ref_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    ref_dg, ref_dh0 = g.grad.clone(), h0.grad.clone()
+
+    _assert_close("o", ref, tri, 0.004)
+    _assert_close("ht", ref_ht, tri_ht, 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0, 0.005)
+
+
+@pytest.mark.parametrize(
+    ("B", "T", "H", "D", "dtype"),
+    [
+        pytest.param(*c, id="B{}-T{}-H{}-D{}-{}".format(*c))
+        for c in [
+            (2, 256, 4, 64, torch.float),
+            (2, 1024, 4, 128, torch.float16),
+        ]
+    ],
+)
+def test_chunk_state_v_first(B, T, H, D, dtype):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = torch.device("cuda")
+
+    q = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, T, H, D, dtype=dtype, device=device)
+    g = F.logsigmoid(torch.rand(B, T, H, D, dtype=dtype, device=device))
+    h0 = torch.rand(B, H, D, D, dtype=torch.float32, device=device)
+    do = torch.randn_like(v)
+    dht = torch.randn_like(h0)
+
+    def run(state_v_first):
+        q_ = q.detach().clone().requires_grad_()
+        k_ = k.detach().clone().requires_grad_()
+        v_ = v.detach().clone().requires_grad_()
+        g_ = g.detach().clone().requires_grad_()
+        h0_in = h0.transpose(-1, -2).contiguous() if state_v_first else h0.clone()
+        dht_in = dht.transpose(-1, -2).contiguous() if state_v_first else dht
+        h0_in = h0_in.requires_grad_()
+        out, ht = chunk_gla(
+            q=q_,
+            k=k_,
+            v=v_,
+            g=g_,
+            scale=D**-0.5,
+            initial_state=h0_in,
+            output_final_state=True,
+            state_v_first=state_v_first,
+        )
+        ((out * do).sum() + (ht * dht_in).sum()).backward()
+        return out, ht, q_.grad, k_.grad, v_.grad, g_.grad, h0_in.grad
+
+    ref_o, ref_ht, ref_dq, ref_dk, ref_dv, ref_dg, ref_dh0 = run(False)
+    tri_o, tri_ht, tri_dq, tri_dk, tri_dv, tri_dg, tri_dh0 = run(True)
+
+    _assert_close("o", ref_o, tri_o, 0.005)
+    _assert_close("ht", ref_ht, tri_ht.transpose(-1, -2), 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0.transpose(-1, -2), 0.005)
+
+
+@pytest.mark.parametrize(
+    ("H", "D", "cu_seqlens", "dtype"),
+    [
+        pytest.param(*c, id="H{}-D{}-cu_seqlens{}-{}".format(*c))
+        for c in [
+            (4, 64, [0, 15], torch.float16),
+            (4, 64, [0, 256, 500, 1000], torch.float16),
+            (4, 100, [0, 15, 100, 300, 1200, 2000], torch.float16),
+        ]
+    ],
+)
+def test_chunk_varlen(H, D, cu_seqlens, dtype):
+    torch.manual_seed(42)
+    os.environ["TRITON_F32_DEFAULT"] = "ieee"
+    device = torch.device("cuda")
+
+    N = len(cu_seqlens) - 1
+    T = cu_seqlens[-1]
+    cu = torch.tensor(cu_seqlens, dtype=torch.int32, device=device)
+
+    q = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    k = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    v = torch.rand(1, T, H, D, dtype=dtype, device=device).requires_grad_()
+    g = F.logsigmoid(
+        torch.rand(1, T, H, D, dtype=dtype, device=device)
+    ).requires_grad_()
+    h0 = torch.rand(N, H, D, D, dtype=torch.float32, device=device).requires_grad_()
+    do = torch.randn_like(v)
+    dht = torch.rand(N, H, D, D, dtype=torch.float32, device=device)
+
+    ref, ref_ht = fused_recurrent_gla(
+        q=q,
+        k=k,
+        v=v,
+        gk=g,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+    )
+    ((ref * do).sum() + (ref_ht * dht).sum().to(do.dtype)).backward()
+    ref_dq, ref_dk, ref_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    ref_dg, ref_dh0 = g.grad.clone(), h0.grad.clone()
+    q.grad = k.grad = v.grad = g.grad = h0.grad = None
+
+    tri, tri_ht = chunk_gla(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        scale=D**-0.5,
+        initial_state=h0,
+        output_final_state=True,
+        cu_seqlens=cu,
+    )
+    ((tri * do).sum() + (tri_ht * dht).sum()).backward()
+    tri_dq, tri_dk, tri_dv = q.grad.clone(), k.grad.clone(), v.grad.clone()
+    tri_dg, tri_dh0 = g.grad.clone(), h0.grad.clone()
+
+    _assert_close("o", ref, tri, 0.004)
+    _assert_close("ht", ref_ht, tri_ht, 0.005)
+    _assert_close("dq", ref_dq, tri_dq, 0.005)
+    _assert_close("dk", ref_dk, tri_dk, 0.005)
+    _assert_close("dv", ref_dv, tri_dv, 0.005)
+    _assert_close("dg", ref_dg, tri_dg, 0.005)
+    _assert_close("dh0", ref_dh0, tri_dh0, 0.005)

--- a/tests/flag_attn/test_chunk_gla.py
+++ b/tests/flag_attn/test_chunk_gla.py
@@ -931,6 +931,7 @@ def _assert_close(name, actual, expected, ratio, err_atol=1e-6):
     assert error_rate < ratio, f"{name}: diff: {abs_atol:.6f} ratio: {error_rate:.6f}"
 
 
+@pytest.mark.chunk_gla_chunk
 @pytest.mark.parametrize(
     ("B", "T", "H", "D", "gate_logit_normalizer", "dtype"),
     [
@@ -997,6 +998,7 @@ def test_chunk(B, T, H, D, dtype, gate_logit_normalizer):
     _assert_close("dh0", ref_dh0, tri_dh0, 0.005)
 
 
+@pytest.mark.chunk_gla_state_v_first
 @pytest.mark.parametrize(
     ("B", "T", "H", "D", "dtype"),
     [
@@ -1053,6 +1055,7 @@ def test_chunk_state_v_first(B, T, H, D, dtype):
     _assert_close("dh0", ref_dh0, tri_dh0.transpose(-1, -2), 0.005)
 
 
+@pytest.mark.chunk_gla_varlen
 @pytest.mark.parametrize(
     ("H", "D", "cu_seqlens", "dtype"),
     [

--- a/tests/flag_attn/test_minimax_sparse_attention.py
+++ b/tests/flag_attn/test_minimax_sparse_attention.py
@@ -1,3 +1,18 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """CUDA correctness tests for the MiniMax M3 paged MSA kernels."""
 
 from __future__ import annotations

--- a/tests/flag_attn/test_minimax_sparse_attention.py
+++ b/tests/flag_attn/test_minimax_sparse_attention.py
@@ -1,22 +1,8 @@
-#!/usr/bin/env python3
-# Copyright 2026 FlagOS Contributors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 """CUDA correctness tests for the MiniMax M3 paged MSA kernels."""
 
 from __future__ import annotations
 
+import importlib
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -32,6 +18,8 @@ from flag_attn.minimax_sparse_attention import (
     minimax_m3_sparse_attn,
     minimax_m3_sparse_attn_decode,
 )
+
+index_topk_module = importlib.import_module("flag_attn.minimax_sparse_attention.index_topk")
 
 triton.knobs.autotuning.adjust_block_size = False
 BLOCK = SPARSE_BLOCK_SIZE
@@ -359,19 +347,20 @@ def _ref_decode_index(
         for query_index in range(decode_qlen):
             query_id = request * decode_qlen + query_index
             query_pos = seq_len - decode_qlen + query_index
-            valid_blocks = (query_pos + BLOCK) // BLOCK
+            kv_len = query_pos + 1
+            valid_blocks = (kv_len + BLOCK - 1) // BLOCK
             query = data.idx_q[query_id].float()
             for block in range(valid_blocks):
                 page = int(data.block_table[request, block].item())
-                valid_tokens = min(BLOCK, seq_len - block * BLOCK)
+                valid_tokens = min(BLOCK, kv_len - block * BLOCK)
                 keys = data.index_kv_cache[page, :valid_tokens].float()
                 scores[:, query_id, block] = torch.einsum(
                     "hd,kd->hk", query, keys
                 ).amax(dim=-1)
-            local_start = max(0, valid_blocks - local_blocks)
-            scores[:, query_id, local_start:valid_blocks] = 1e29
             init_end = min(init_blocks, valid_blocks)
             scores[:, query_id, :init_end] = 1e30
+            local_start = max(0, valid_blocks - local_blocks)
+            scores[:, query_id, local_start:valid_blocks] = 1e29
 
     result = torch.full(
         (num_idx_heads, data.q.shape[0], topk),
@@ -611,31 +600,195 @@ def _run_decode(case: tuple, mode: str) -> None:
     _assert_attention_match(output, ref_output, data)
 
 
+def test_prefill_topk_streaming_partial_tile_excludes_padding() -> None:
+    """Invalid lanes must lose even when every valid score is negative infinity."""
+    num_score_blocks = 96
+    valid_blocks = 70
+    topk = 16
+    score = torch.full(
+        (1, 1, num_score_blocks),
+        -float("inf"),
+        device="cuda",
+        dtype=torch.float32,
+    )
+    cu_seqlens_q = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+    prefix_lens = torch.tensor(
+        [(valid_blocks - 1) * BLOCK], device="cuda", dtype=torch.int32
+    )
+
+    assert index_topk_module._select_prefill_topk_path(score, topk, 1) == "streaming"
+    actual = minimax_m3_index_topk(
+        score,
+        cu_seqlens_q,
+        prefix_lens,
+        1,
+        topk,
+        0,
+        0,
+    )
+    torch.cuda.synchronize()
+
+    expected = torch.arange(topk, device="cuda", dtype=torch.int32).view(1, 1, topk)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.skipif(
+    not index_topk_module._HAS_TLE,
+    reason="requires FlagTree 3.6+ with TLE",
+)
+def test_prefill_topk_radix_path() -> None:
+    """Exercise the actual wide-row TLE path instead of accepting fallback."""
+    num_score_blocks = 1024
+    topk = 16
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(123)
+    score = torch.randn(
+        (1, 1, num_score_blocks),
+        generator=generator,
+        device="cuda",
+        dtype=torch.float32,
+    )
+    cu_seqlens_q = torch.tensor([0, 1], device="cuda", dtype=torch.int32)
+    prefix_lens = torch.tensor(
+        [(num_score_blocks - 1) * BLOCK], device="cuda", dtype=torch.int32
+    )
+    block_size_k, _ = index_topk_module._radix_prefill_launch_config(num_score_blocks)
+    config_key = (block_size_k, topk)
+    index_topk_module._FAILED_RADIX_CONFIGS.discard(config_key)
+
+    assert index_topk_module._select_prefill_topk_path(score, topk, 1) == "radix"
+    actual = minimax_m3_index_topk(
+        score,
+        cu_seqlens_q,
+        prefix_lens,
+        1,
+        topk,
+        0,
+        0,
+    )
+    torch.cuda.synchronize()
+
+    assert config_key not in index_topk_module._FAILED_RADIX_CONFIGS
+    expected = torch.topk(score, topk, dim=-1).indices.to(torch.int32)
+    expected = expected.sort(dim=-1).values
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
 PREFILL_CASES = [
+    # Boundary and padding: valid_blocks=2, topk=4.
     ((129,), (0,), 1, 16, 4, 1, 2),
-    ((257, 513, 129), (0, 64, 128), 2, 8, 8, 1, 2),
-    ((1025, 257, 513, 65), (256, 64, 128, 0), 4, 4, 16, 2, 3),
+    # Selection: 1024 tokens -> 8 blocks, topk=4.
+    ((1024,), (0,), 2, 8, 4, 1, 2),
+    # Ragged/prefix selection: late queries see 32/16/9 blocks, topk=8.
+    ((4096, 2048, 1025), (0, 256, 128), 4, 4, 8, 1, 2),
 ]
 
 DECODE_CASES = [
-    ((129,), 1, 16, 4, 1, 2, 1),
-    ((257, 513, 129), 2, 8, 8, 1, 2, 4),
-    ((1025, 257, 513, 65, 129), 4, 4, 16, 2, 3, 8),
+    # Boundary and selection: 512 tokens -> 4 blocks, topk=3.
+    ((512,), 1, 16, 3, 1, 2, 1),
+    # Ragged selection: late queries see 16/8/5 blocks, topk=4.
+    ((2048, 1024, 513), 2, 8, 4, 1, 2, 4),
+    # Long GQA case with both selection and a short padding request.
+    ((8192, 2048, 1025, 129), 4, 4, 8, 2, 3, 8),
+]
+
+DECODE_SELECTION_CASES = [
+    ((4097,), 1, 1, 8, 1, 2, 1),
+    ((1025,) * 16, 4, 1, 4, 1, 2, 1),
+]
+
+DECODE_K16_CASES = [
+    ((2048, 1025), 2, 8, 16, 1, 2, 4),
+    ((4100,), 1, 1, 16, 0, 0, 4),
 ]
 
 
 @pytest.mark.parametrize(
-    "case", PREFILL_CASES, ids=("short", "ragged_prefix", "padded_batch")
+    "case", PREFILL_CASES, ids=("boundary", "selection", "long_ragged")
 )
 def test_prefill_bf16(case: tuple) -> None:
     _run_prefill(case, "bf16")
 
 
 @pytest.mark.parametrize(
-    "case", DECODE_CASES, ids=("short", "spec_decode", "padded_batch")
+    "case", DECODE_CASES, ids=("boundary", "selection", "long_gqa")
 )
 def test_decode_bf16(case: tuple) -> None:
     _run_decode(case, "bf16")
+
+
+@pytest.mark.parametrize(
+    "case", DECODE_SELECTION_CASES, ids=("split_k", "single_chunk")
+)
+def test_decode_topk_selection_bf16(case: tuple) -> None:
+    """Cover N > K for both multi-chunk and single-chunk selection."""
+    _run_decode(case, "bf16")
+
+
+@pytest.mark.parametrize(
+    "case", DECODE_K16_CASES, ids=("identity_ragged", "spec_causal")
+)
+def test_decode_topk_k16_bf16(case: tuple) -> None:
+    """Cover the configured K=16 Identity and causal selection paths."""
+    _run_decode(case, "bf16")
+
+
+def test_decode_topk_identity_out_and_score_out_bf16() -> None:
+    """Identity must preserve out aliasing and populate an explicit score buffer."""
+    seq_lens = (2048, 1025)
+    num_kv_heads = 2
+    topk = 16
+    decode_qlen = 4
+    data = make_data(
+        seq_lens,
+        num_kv_heads,
+        8,
+        decode=True,
+        decode_qlen=decode_qlen,
+        mode="bf16",
+    )
+    total_q = data.q.shape[0]
+    max_blocks = (data.max_seq_len + BLOCK - 1) // BLOCK
+    out = torch.full(
+        (num_kv_heads, total_q + 1, topk),
+        -2,
+        device="cuda",
+        dtype=torch.int32,
+    )
+    score_out = torch.full(
+        (num_kv_heads, total_q, max_blocks),
+        float("nan"),
+        device="cuda",
+        dtype=torch.float32,
+    )
+
+    actual = minimax_m3_index_decode(
+        data.idx_q,
+        data.index_kv_cache,
+        data.block_table,
+        data.seq_lens,
+        data.max_seq_len,
+        topk,
+        1,
+        2,
+        num_kv_heads,
+        decode_qlen,
+        decode_qlen,
+        out=out,
+        score_out=score_out,
+    )
+    torch.cuda.synchronize()
+
+    expected = _ref_decode_index(data, topk, 1, 2, decode_qlen)
+    _assert_topk_match(actual, expected, data, topk, decode=True)
+    assert actual.data_ptr() == out.data_ptr()
+    assert torch.all(out[:, total_q] == -2)
+    for request, seq_len in enumerate(seq_lens):
+        for query_index in range(decode_qlen):
+            query_id = request * decode_qlen + query_index
+            kv_len = seq_len - decode_qlen + query_index + 1
+            valid_blocks = (kv_len + BLOCK - 1) // BLOCK
+            assert torch.all(torch.isfinite(score_out[:, query_id, :valid_blocks]))
 
 
 @pytest.mark.skipif(
@@ -643,7 +796,7 @@ def test_decode_bf16(case: tuple) -> None:
     reason="FP8 tests require an NVIDIA GPU with FP8 support",
 )
 @pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
-@pytest.mark.parametrize("case", PREFILL_CASES[:2], ids=("short", "ragged_prefix"))
+@pytest.mark.parametrize("case", PREFILL_CASES[:2], ids=("boundary", "selection"))
 def test_prefill_fp8(mode: str, case: tuple) -> None:
     _run_prefill(case, mode)
 
@@ -653,6 +806,6 @@ def test_prefill_fp8(mode: str, case: tuple) -> None:
     reason="FP8 tests require an NVIDIA GPU with FP8 support",
 )
 @pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
-@pytest.mark.parametrize("case", DECODE_CASES[:2], ids=("short", "spec_decode"))
+@pytest.mark.parametrize("case", DECODE_CASES[:2], ids=("boundary", "selection"))
 def test_decode_fp8(mode: str, case: tuple) -> None:
     _run_decode(case, mode)

--- a/tests/flag_attn/test_minimax_sparse_attention.py
+++ b/tests/flag_attn/test_minimax_sparse_attention.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2026 FlagOS Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -615,6 +614,7 @@ def _run_decode(case: tuple, mode: str) -> None:
     _assert_attention_match(output, ref_output, data)
 
 
+@pytest.mark.minimax_sparse_attention_topk
 def test_prefill_topk_streaming_partial_tile_excludes_padding() -> None:
     """Invalid lanes must lose even when every valid score is negative infinity."""
     num_score_blocks = 96
@@ -651,6 +651,7 @@ def test_prefill_topk_streaming_partial_tile_excludes_padding() -> None:
     not index_topk_module._HAS_TLE,
     reason="requires FlagTree 3.6+ with TLE",
 )
+@pytest.mark.minimax_sparse_attention_topk
 def test_prefill_topk_radix_path() -> None:
     """Exercise the actual wide-row TLE path instead of accepting fallback."""
     num_score_blocks = 1024
@@ -721,6 +722,7 @@ DECODE_K16_CASES = [
 @pytest.mark.parametrize(
     "case", PREFILL_CASES, ids=("boundary", "selection", "long_ragged")
 )
+@pytest.mark.minimax_sparse_attention_prefill
 def test_prefill_bf16(case: tuple) -> None:
     _run_prefill(case, "bf16")
 
@@ -728,6 +730,7 @@ def test_prefill_bf16(case: tuple) -> None:
 @pytest.mark.parametrize(
     "case", DECODE_CASES, ids=("boundary", "selection", "long_gqa")
 )
+@pytest.mark.minimax_sparse_attention_decode
 def test_decode_bf16(case: tuple) -> None:
     _run_decode(case, "bf16")
 
@@ -735,6 +738,7 @@ def test_decode_bf16(case: tuple) -> None:
 @pytest.mark.parametrize(
     "case", DECODE_SELECTION_CASES, ids=("split_k", "single_chunk")
 )
+@pytest.mark.minimax_sparse_attention_decode
 def test_decode_topk_selection_bf16(case: tuple) -> None:
     """Cover N > K for both multi-chunk and single-chunk selection."""
     _run_decode(case, "bf16")
@@ -743,11 +747,13 @@ def test_decode_topk_selection_bf16(case: tuple) -> None:
 @pytest.mark.parametrize(
     "case", DECODE_K16_CASES, ids=("identity_ragged", "spec_causal")
 )
+@pytest.mark.minimax_sparse_attention_decode
 def test_decode_topk_k16_bf16(case: tuple) -> None:
     """Cover the configured K=16 Identity and causal selection paths."""
     _run_decode(case, "bf16")
 
 
+@pytest.mark.minimax_sparse_attention_decode
 def test_decode_topk_identity_out_and_score_out_bf16() -> None:
     """Identity must preserve out aliasing and populate an explicit score buffer."""
     seq_lens = (2048, 1025)
@@ -812,6 +818,7 @@ def test_decode_topk_identity_out_and_score_out_bf16() -> None:
 )
 @pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
 @pytest.mark.parametrize("case", PREFILL_CASES[:2], ids=("boundary", "selection"))
+@pytest.mark.minimax_sparse_attention_prefill
 def test_prefill_fp8(mode: str, case: tuple) -> None:
     _run_prefill(case, mode)
 
@@ -822,5 +829,6 @@ def test_prefill_fp8(mode: str, case: tuple) -> None:
 )
 @pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
 @pytest.mark.parametrize("case", DECODE_CASES[:2], ids=("boundary", "selection"))
+@pytest.mark.minimax_sparse_attention_decode
 def test_decode_fp8(mode: str, case: tuple) -> None:
     _run_decode(case, mode)

--- a/tests/flag_attn/test_minimax_sparse_attention.py
+++ b/tests/flag_attn/test_minimax_sparse_attention.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CUDA correctness tests for the MiniMax M3 paged MSA kernels."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import pytest
+import torch
+import triton.knobs
+
+from flag_attn.minimax_sparse_attention import (
+    SPARSE_BLOCK_SIZE,
+    minimax_m3_index_decode,
+    minimax_m3_index_score,
+    minimax_m3_index_topk,
+    minimax_m3_sparse_attn,
+    minimax_m3_sparse_attn_decode,
+)
+
+triton.knobs.autotuning.adjust_block_size = False
+BLOCK = SPARSE_BLOCK_SIZE
+HEAD_DIM = 128
+FP8_DTYPE = getattr(torch, "float8_e4m3fn", None)
+BF16_SCORE_ATOL = 2e-2
+BF16_SCORE_RTOL = 2e-2
+FP8_SCORE_ATOL = 2e-1
+FP8_SCORE_RTOL = 1.5e-1
+BF16_ATOL = 2e-2
+BF16_RTOL = 2e-2
+FP8_ATOL = 6e-2
+FP8_RTOL = 8e-2
+
+
+def _supports_fp8() -> bool:
+    if FP8_DTYPE is None or not torch.cuda.is_available():
+        return False
+    # NVIDIA FP8 Tensor Core support starts with Ada (8.9) and Hopper (9.0).
+    return torch.cuda.get_device_capability() >= (8, 9)
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="MSA v1 tests require CUDA"
+)
+
+
+@dataclass
+class MSAData:
+    q: torch.Tensor
+    idx_q: torch.Tensor
+    kv_cache: torch.Tensor
+    index_kv_cache: torch.Tensor
+    block_table: torch.Tensor
+    cu_q: torch.Tensor
+    seq_lens: torch.Tensor
+    prefix_lens: torch.Tensor
+    query_lens: tuple[int, ...]
+    max_seq_len: int
+    sm_scale: float
+    k_scale: torch.Tensor | None
+    v_scale: torch.Tensor | None
+
+
+def _encode_fp8(value: torch.Tensor, scale: float = 1.0) -> torch.Tensor:
+    if FP8_DTYPE is None:
+        pytest.skip("PyTorch does not provide float8_e4m3fn")
+    return (value / scale).to(FP8_DTYPE)
+
+
+def _storage(
+    shape: tuple[int, ...],
+    device: torch.device,
+    use_fp8: bool,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    value = torch.randn(shape, device=device, dtype=torch.bfloat16) * 0.5
+    return _encode_fp8(value, scale) if use_fp8 else value
+
+
+def make_data(
+    seq_lens: Sequence[int],
+    num_kv_heads: int,
+    group_size: int,
+    *,
+    decode: bool,
+    decode_qlen: int = 1,
+    prefix_lens: Sequence[int] | None = None,
+    mode: str = "bf16",
+    seed: int = 42,
+) -> MSAData:
+    if mode not in {"bf16", "fp8_index", "fp8_kv", "fp8_full"}:
+        raise ValueError(f"unsupported mode: {mode}")
+    if mode != "bf16" and not _supports_fp8():
+        pytest.skip("FP8 tests require an NVIDIA GPU with FP8 support")
+    if not seq_lens or any(length <= 0 for length in seq_lens):
+        raise ValueError("seq_lens must contain positive lengths")
+    if num_kv_heads <= 0 or group_size <= 0:
+        raise ValueError("head counts must be positive")
+    if decode and decode_qlen > min(seq_lens):
+        raise ValueError("decode_qlen must not exceed the shortest sequence")
+
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    batch = len(seq_lens)
+    max_seq_len = max(seq_lens)
+    if decode:
+        query_lens = (decode_qlen,) * batch
+        prefix_values = (0,) * batch
+    else:
+        prefix_values = tuple(prefix_lens) if prefix_lens is not None else (0,) * batch
+        if len(prefix_values) != batch:
+            raise ValueError("prefix_lens and seq_lens must have equal lengths")
+        if any(
+            prefix < 0 or prefix >= seq for prefix, seq in zip(prefix_values, seq_lens)
+        ):
+            raise ValueError("each prefix length must be in [0, seq_len)")
+        query_lens = tuple(seq - prefix for seq, prefix in zip(seq_lens, prefix_values))
+
+    if num_kv_heads * group_size <= 0:
+        raise ValueError("invalid number of query heads")
+    total_q = sum(query_lens)
+    num_heads = num_kv_heads * group_size
+    index_fp8 = mode in {"fp8_index", "fp8_full"}
+    kv_fp8 = mode in {"fp8_kv", "fp8_full"}
+    kv_scale_value = 0.5
+
+    q = (
+        torch.randn((total_q, num_heads, HEAD_DIM), device=device, dtype=torch.bfloat16)
+        * 0.5
+    )
+    idx_q = _storage((total_q, num_kv_heads, HEAD_DIM), device, index_fp8)
+
+    blocks_per_request = [(seq + BLOCK - 1) // BLOCK for seq in seq_lens]
+    total_blocks = sum(blocks_per_request)
+    max_blocks = max(blocks_per_request)
+    logical_kv = torch.empty(
+        (total_blocks, num_kv_heads, BLOCK, 2 * HEAD_DIM),
+        device=device,
+        dtype=torch.float8_e4m3fn if kv_fp8 else torch.bfloat16,
+    )
+    logical_k = _storage(
+        (total_blocks * BLOCK, num_kv_heads, HEAD_DIM),
+        device,
+        kv_fp8,
+        kv_scale_value,
+    )
+    logical_v = _storage(
+        (total_blocks * BLOCK, num_kv_heads, HEAD_DIM),
+        device,
+        kv_fp8,
+        kv_scale_value,
+    )
+    logical_k = logical_k.reshape(total_blocks, BLOCK, num_kv_heads, HEAD_DIM).permute(
+        0, 2, 1, 3
+    )
+    logical_v = logical_v.reshape(total_blocks, BLOCK, num_kv_heads, HEAD_DIM).permute(
+        0, 2, 1, 3
+    )
+    logical_kv[..., :HEAD_DIM] = logical_k
+    logical_kv[..., HEAD_DIM:] = logical_v
+
+    logical_index_k = _storage(
+        (total_blocks * BLOCK, HEAD_DIM), device, index_fp8
+    ).reshape(total_blocks, BLOCK, HEAD_DIM)
+    physical_pages = torch.randperm(total_blocks, device=device)
+    block_table = torch.zeros((batch, max_blocks), device=device, dtype=torch.int32)
+    offset = 0
+    for request, num_blocks in enumerate(blocks_per_request):
+        block_table[request, :num_blocks] = physical_pages[offset : offset + num_blocks]
+        offset += num_blocks
+
+    kv_cache = torch.empty_like(logical_kv)
+    index_kv_cache = torch.empty_like(logical_index_k)
+    kv_cache[physical_pages] = logical_kv
+    index_kv_cache[physical_pages] = logical_index_k
+
+    cu_q = torch.tensor(
+        [0, *torch.tensor(query_lens).cumsum(0).tolist()],
+        device=device,
+        dtype=torch.int32,
+    )
+    seq_lens_tensor = torch.tensor(seq_lens, device=device, dtype=torch.int32)
+    prefix_lens_tensor = torch.tensor(prefix_values, device=device, dtype=torch.int32)
+    if kv_fp8:
+        k_scale = torch.tensor([kv_scale_value], device=device, dtype=torch.float32)
+        v_scale = torch.tensor([kv_scale_value], device=device, dtype=torch.float32)
+    else:
+        k_scale = v_scale = None
+    return MSAData(
+        q=q,
+        idx_q=idx_q,
+        kv_cache=kv_cache,
+        index_kv_cache=index_kv_cache,
+        block_table=block_table,
+        cu_q=cu_q,
+        seq_lens=seq_lens_tensor,
+        prefix_lens=prefix_lens_tensor,
+        query_lens=tuple(query_lens),
+        max_seq_len=max_seq_len,
+        sm_scale=HEAD_DIM**-0.5,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+
+
+def _ref_index_score(data: MSAData) -> torch.Tensor:
+    batch = len(data.query_lens)
+    num_idx_heads = data.idx_q.shape[1]
+    max_blocks = (data.max_seq_len + BLOCK - 1) // BLOCK
+    scores = torch.full(
+        (num_idx_heads, data.q.shape[0], max_blocks),
+        float("-inf"),
+        device=data.q.device,
+        dtype=torch.float32,
+    )
+    for request in range(batch):
+        q_start = int(data.cu_q[request].item())
+        q_end = int(data.cu_q[request + 1].item())
+        seq_len = int(data.seq_lens[request].item())
+        prefix_len = int(data.prefix_lens[request].item())
+        query_len = q_end - q_start
+        for block in range((seq_len + BLOCK - 1) // BLOCK):
+            page = int(data.block_table[request, block].item())
+            valid_tokens = min(BLOCK, seq_len - block * BLOCK)
+            keys = data.index_kv_cache[page, :valid_tokens].float()
+            queries = data.idx_q[q_start:q_end].float()
+            qk = torch.einsum("qhd,kd->qhk", queries, keys)
+            key_positions = torch.arange(
+                block * BLOCK,
+                block * BLOCK + valid_tokens,
+                device=data.q.device,
+            )
+            query_positions = torch.arange(query_len, device=data.q.device) + prefix_len
+            causal = key_positions[None, :] <= query_positions[:, None]
+            qk = qk.masked_fill(~causal[:, None, :], float("-inf"))
+            scores[:, q_start:q_end, block] = qk.amax(dim=-1).transpose(0, 1)
+    return scores
+
+
+def _ref_topk(
+    scores: torch.Tensor,
+    data: MSAData,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+) -> torch.Tensor:
+    num_idx_heads, total_q, _ = scores.shape
+    result = torch.full(
+        (num_idx_heads, total_q, topk),
+        -1,
+        device=scores.device,
+        dtype=torch.int32,
+    )
+    for request, query_len in enumerate(data.query_lens):
+        q_start = int(data.cu_q[request].item())
+        prefix_len = int(data.prefix_lens[request].item())
+        for query_index in range(query_len):
+            query_pos = prefix_len + query_index
+            valid_blocks = (query_pos + BLOCK) // BLOCK
+            num_selected = min(topk, valid_blocks)
+            if num_selected == 0:
+                continue
+            current = scores[:, q_start + query_index, :valid_blocks].clone()
+            local_start = max(0, valid_blocks - local_blocks)
+            current[:, local_start:valid_blocks] = 1e29
+            init_end = min(init_blocks, valid_blocks)
+            if init_end:
+                current[:, :init_end] = torch.where(
+                    current[:, :init_end] < 1e29,
+                    torch.full_like(current[:, :init_end], 1e30),
+                    current[:, :init_end],
+                )
+            result[:, q_start + query_index, :num_selected] = current.topk(
+                num_selected, dim=-1
+            ).indices.to(torch.int32)
+    return result
+
+
+def _dequantized_kv(
+    data: MSAData, page: int, kv_head: int, valid_tokens: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    keys = data.kv_cache[page, kv_head, :valid_tokens, :HEAD_DIM].float()
+    values = data.kv_cache[page, kv_head, :valid_tokens, HEAD_DIM:].float()
+    if data.k_scale is not None:
+        keys = keys * data.k_scale.item()
+        values = values * data.v_scale.item()
+    return keys, values
+
+
+def _ref_sparse_attn(data: MSAData, topk_idx: torch.Tensor) -> torch.Tensor:
+    output = torch.zeros_like(data.q)
+    num_kv_heads = data.kv_cache.shape[1]
+    group_size = data.q.shape[1] // num_kv_heads
+    for request, query_len in enumerate(data.query_lens):
+        q_start = int(data.cu_q[request].item())
+        seq_len = int(data.seq_lens[request].item())
+        prefix_len = int(data.prefix_lens[request].item())
+        for query_index in range(query_len):
+            query_id = q_start + query_index
+            max_k = min(prefix_len + query_index + 1, seq_len)
+            for kv_head in range(num_kv_heads):
+                selected = topk_idx[kv_head, query_id]
+                keys_parts = []
+                values_parts = []
+                for block_value in selected[selected >= 0]:
+                    block = int(block_value.item())
+                    block_start = block * BLOCK
+                    valid_tokens = min(BLOCK, max_k - block_start)
+                    if valid_tokens <= 0:
+                        continue
+                    page = int(data.block_table[request, block].item())
+                    keys, values = _dequantized_kv(data, page, kv_head, valid_tokens)
+                    keys_parts.append(keys)
+                    values_parts.append(values)
+                if not keys_parts:
+                    continue
+                keys = torch.cat(keys_parts, dim=0)
+                values = torch.cat(values_parts, dim=0)
+                head_start = kv_head * group_size
+                head_end = head_start + group_size
+                query = data.q[query_id, head_start:head_end].float()
+                logits = (query @ keys.transpose(0, 1)) * data.sm_scale
+                weights = torch.softmax(logits, dim=-1)
+                output[query_id, head_start:head_end] = (weights @ values).to(
+                    output.dtype
+                )
+    return output
+
+
+def _ref_decode_index(
+    data: MSAData, topk: int, init_blocks: int, local_blocks: int, decode_qlen: int
+) -> torch.Tensor:
+    num_requests = len(data.query_lens)
+    num_idx_heads = data.idx_q.shape[1]
+    max_blocks = (data.max_seq_len + BLOCK - 1) // BLOCK
+    scores = torch.full(
+        (num_idx_heads, data.q.shape[0], max_blocks),
+        float("-inf"),
+        device=data.q.device,
+        dtype=torch.float32,
+    )
+    for request in range(num_requests):
+        seq_len = int(data.seq_lens[request].item())
+        for query_index in range(decode_qlen):
+            query_id = request * decode_qlen + query_index
+            query_pos = seq_len - decode_qlen + query_index
+            valid_blocks = (query_pos + BLOCK) // BLOCK
+            query = data.idx_q[query_id].float()
+            for block in range(valid_blocks):
+                page = int(data.block_table[request, block].item())
+                valid_tokens = min(BLOCK, seq_len - block * BLOCK)
+                keys = data.index_kv_cache[page, :valid_tokens].float()
+                scores[:, query_id, block] = torch.einsum(
+                    "hd,kd->hk", query, keys
+                ).amax(dim=-1)
+            local_start = max(0, valid_blocks - local_blocks)
+            scores[:, query_id, local_start:valid_blocks] = 1e29
+            init_end = min(init_blocks, valid_blocks)
+            scores[:, query_id, :init_end] = 1e30
+
+    result = torch.full(
+        (num_idx_heads, data.q.shape[0], topk),
+        -1,
+        device=data.q.device,
+        dtype=torch.int32,
+    )
+    for request in range(num_requests):
+        seq_len = int(data.seq_lens[request].item())
+        for query_index in range(decode_qlen):
+            query_id = request * decode_qlen + query_index
+            query_pos = seq_len - decode_qlen + query_index
+            valid_blocks = (query_pos + BLOCK) // BLOCK
+            num_selected = min(topk, valid_blocks)
+            result[:, query_id, :num_selected] = (
+                scores[:, query_id, :valid_blocks]
+                .topk(num_selected, dim=-1)
+                .indices.to(torch.int32)
+            )
+    return result
+
+
+def _ref_decode_attn(
+    data: MSAData, topk_idx: torch.Tensor, decode_qlen: int
+) -> torch.Tensor:
+    output = torch.zeros_like(data.q)
+    num_requests = len(data.query_lens)
+    num_kv_heads = data.kv_cache.shape[1]
+    group_size = data.q.shape[1] // num_kv_heads
+    for request in range(num_requests):
+        seq_len = int(data.seq_lens[request].item())
+        for query_index in range(decode_qlen):
+            query_id = request * decode_qlen + query_index
+            max_k = seq_len - decode_qlen + query_index + 1
+            for kv_head in range(num_kv_heads):
+                keys_parts = []
+                values_parts = []
+                for block_value in topk_idx[kv_head, query_id]:
+                    if block_value < 0:
+                        continue
+                    block = int(block_value.item())
+                    block_start = block * BLOCK
+                    valid_tokens = min(BLOCK, max_k - block_start)
+                    if valid_tokens <= 0:
+                        continue
+                    page = int(data.block_table[request, block].item())
+                    keys, values = _dequantized_kv(data, page, kv_head, valid_tokens)
+                    keys_parts.append(keys)
+                    values_parts.append(values)
+                if not keys_parts:
+                    continue
+                keys = torch.cat(keys_parts, dim=0)
+                values = torch.cat(values_parts, dim=0)
+                head_start = kv_head * group_size
+                head_end = head_start + group_size
+                query = data.q[query_id, head_start:head_end].float()
+                logits = (query @ keys.transpose(0, 1)) * data.sm_scale
+                weights = torch.softmax(logits, dim=-1)
+                output[query_id, head_start:head_end] = (weights @ values).to(
+                    output.dtype
+                )
+    return output
+
+
+def _assert_score_match(
+    actual: torch.Tensor, expected: torch.Tensor, data: MSAData, decode: bool
+) -> None:
+    atol = FP8_SCORE_ATOL if data.idx_q.dtype == FP8_DTYPE else BF16_SCORE_ATOL
+    rtol = FP8_SCORE_RTOL if data.idx_q.dtype == FP8_DTYPE else BF16_SCORE_RTOL
+    for request, query_len in enumerate(data.query_lens):
+        q_start = int(data.cu_q[request].item())
+        for query_index in range(query_len):
+            if decode:
+                query_pos = int(data.seq_lens[request].item()) - query_len + query_index
+            else:
+                query_pos = int(data.prefix_lens[request].item()) + query_index
+            valid_blocks = (query_pos + BLOCK) // BLOCK
+            torch.testing.assert_close(
+                actual[:, q_start + query_index, :valid_blocks],
+                expected[:, q_start + query_index, :valid_blocks],
+                atol=atol,
+                rtol=rtol,
+                equal_nan=True,
+            )
+
+
+def _assert_topk_match(
+    actual: torch.Tensor, expected: torch.Tensor, data: MSAData, topk: int, decode: bool
+) -> None:
+    for request, query_len in enumerate(data.query_lens):
+        q_start = int(data.cu_q[request].item())
+        for query_index in range(query_len):
+            query_id = q_start + query_index
+            if decode:
+                query_pos = int(data.seq_lens[request].item()) - query_len + query_index
+            else:
+                query_pos = int(data.prefix_lens[request].item()) + query_index
+            valid_blocks = (query_pos + BLOCK) // BLOCK
+            selected = min(topk, valid_blocks)
+            actual_set = actual[:, query_id, :selected].sort(dim=-1).values
+            expected_set = expected[:, query_id, :selected].sort(dim=-1).values
+            if not torch.equal(actual_set, expected_set):
+                raise AssertionError(
+                    f"top-k set mismatch at request={request}, query={query_index}"
+                )
+            if selected < topk and not torch.all(actual[:, query_id, selected:] == -1):
+                raise AssertionError(
+                    f"top-k padding mismatch at request={request}, query={query_index}"
+                )
+
+
+def _assert_attention_match(
+    actual: torch.Tensor, expected: torch.Tensor, data: MSAData
+) -> None:
+    if not torch.isfinite(actual.float()).all():
+        raise AssertionError("MSA output contains NaN or Inf")
+    fp8 = data.k_scale is not None
+    atol = FP8_ATOL if fp8 else BF16_ATOL
+    rtol = FP8_RTOL if fp8 else BF16_RTOL
+    diff = (actual.float() - expected.float()).abs()
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().reshape(-1), expected.float().reshape(-1), dim=0
+    ).item()
+    try:
+        torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    except AssertionError as exc:
+        raise AssertionError(
+            f"attention mismatch: cosine={cosine:.6f}, "
+            f"max_diff={diff.max().item():.6e}"
+        ) from exc
+
+
+def _run_prefill(case: tuple, mode: str) -> None:
+    seq_lens, prefixes, num_kv_heads, group_size, topk, init_blocks, local_blocks = case
+    data = make_data(
+        seq_lens,
+        num_kv_heads,
+        group_size,
+        decode=False,
+        prefix_lens=prefixes,
+        mode=mode,
+    )
+    scores = minimax_m3_index_score(
+        data.idx_q,
+        data.index_kv_cache,
+        data.block_table,
+        data.cu_q,
+        data.seq_lens,
+        data.prefix_lens,
+        max(data.query_lens),
+        data.max_seq_len,
+        num_kv_heads,
+    )
+    topk_idx = minimax_m3_index_topk(
+        scores,
+        data.cu_q,
+        data.prefix_lens,
+        max(data.query_lens),
+        topk,
+        init_blocks,
+        local_blocks,
+    )
+    output = torch.empty_like(data.q)
+    sparse_kwargs = {}
+    if data.k_scale is not None:
+        sparse_kwargs = {"k_scale": data.k_scale, "v_scale": data.v_scale}
+    minimax_m3_sparse_attn(
+        data.q,
+        data.kv_cache,
+        topk_idx,
+        data.block_table,
+        data.cu_q,
+        data.seq_lens,
+        data.prefix_lens,
+        max(data.query_lens),
+        num_kv_heads,
+        data.sm_scale,
+        output,
+        **sparse_kwargs,
+    )
+    torch.cuda.synchronize()
+
+    ref_scores = _ref_index_score(data)
+    ref_topk = _ref_topk(ref_scores, data, topk, init_blocks, local_blocks)
+    ref_output = _ref_sparse_attn(data, ref_topk)
+    _assert_score_match(scores, ref_scores, data, decode=False)
+    _assert_topk_match(topk_idx, ref_topk, data, topk, decode=False)
+    _assert_attention_match(output, ref_output, data)
+
+
+def _run_decode(case: tuple, mode: str) -> None:
+    seq_lens, num_kv_heads, group_size, topk, init_blocks, local_blocks, decode_qlen = (
+        case
+    )
+    data = make_data(
+        seq_lens,
+        num_kv_heads,
+        group_size,
+        decode=True,
+        decode_qlen=decode_qlen,
+        mode=mode,
+    )
+    topk_idx = minimax_m3_index_decode(
+        data.idx_q,
+        data.index_kv_cache,
+        data.block_table,
+        data.seq_lens,
+        data.max_seq_len,
+        topk,
+        init_blocks,
+        local_blocks,
+        num_kv_heads,
+        decode_qlen,
+        decode_qlen,
+    )
+    output = torch.empty_like(data.q)
+    sparse_kwargs = {}
+    if data.k_scale is not None:
+        sparse_kwargs = {"k_scale": data.k_scale, "v_scale": data.v_scale}
+    minimax_m3_sparse_attn_decode(
+        data.q,
+        data.kv_cache,
+        topk_idx,
+        data.block_table,
+        data.seq_lens,
+        num_kv_heads,
+        data.sm_scale,
+        output,
+        decode_qlen,
+        **sparse_kwargs,
+    )
+    torch.cuda.synchronize()
+
+    ref_topk = _ref_decode_index(data, topk, init_blocks, local_blocks, decode_qlen)
+    ref_output = _ref_decode_attn(data, ref_topk, decode_qlen)
+    _assert_topk_match(topk_idx, ref_topk, data, topk, decode=True)
+    _assert_attention_match(output, ref_output, data)
+
+
+PREFILL_CASES = [
+    ((129,), (0,), 1, 16, 4, 1, 2),
+    ((257, 513, 129), (0, 64, 128), 2, 8, 8, 1, 2),
+    ((1025, 257, 513, 65), (256, 64, 128, 0), 4, 4, 16, 2, 3),
+]
+
+DECODE_CASES = [
+    ((129,), 1, 16, 4, 1, 2, 1),
+    ((257, 513, 129), 2, 8, 8, 1, 2, 4),
+    ((1025, 257, 513, 65, 129), 4, 4, 16, 2, 3, 8),
+]
+
+
+@pytest.mark.parametrize(
+    "case", PREFILL_CASES, ids=("short", "ragged_prefix", "padded_batch")
+)
+def test_prefill_bf16(case: tuple) -> None:
+    _run_prefill(case, "bf16")
+
+
+@pytest.mark.parametrize(
+    "case", DECODE_CASES, ids=("short", "spec_decode", "padded_batch")
+)
+def test_decode_bf16(case: tuple) -> None:
+    _run_decode(case, "bf16")
+
+
+@pytest.mark.skipif(
+    not _supports_fp8(),
+    reason="FP8 tests require an NVIDIA GPU with FP8 support",
+)
+@pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
+@pytest.mark.parametrize("case", PREFILL_CASES[:2], ids=("short", "ragged_prefix"))
+def test_prefill_fp8(mode: str, case: tuple) -> None:
+    _run_prefill(case, mode)
+
+
+@pytest.mark.skipif(
+    not _supports_fp8(),
+    reason="FP8 tests require an NVIDIA GPU with FP8 support",
+)
+@pytest.mark.parametrize("mode", ("fp8_index", "fp8_kv", "fp8_full"))
+@pytest.mark.parametrize("case", DECODE_CASES[:2], ids=("short", "spec_decode"))
+def test_decode_fp8(mode: str, case: tuple) -> None:
+    _run_decode(case, mode)


### PR DESCRIPTION
# MiniMax M3 Paged Sparse Attention Benchmark Results

## Test Environment

```text
benchmark/minimax_sparse_attention_benchmark.py::test_msa_benchmark

Device: NVIDIA H100 80GB HBM3
Compute Capability: 9.0

Baseline: vLLM enabled
Timing: eager execution with CUDA events
```

------
## 1. Prefill — BF16

### Configuration

```text
MiniMax M3 paged sparse attention (prefill)

dtype=bf16
topk=16
init/local=1/2
pages=random
seed=0
warmup=200ms
rep=300ms

Provider order: alternates by shape
```

### Benchmark Results

| Shape `[B,S,KVH,H]` | flag_attn (ms) | vLLM (ms) | vLLM / ours | Score (ms) | TopK (ms) | Attn (ms) |
| ------------------- | ------------- | --------- | ----------- | ---------- | --------- | --------- |
| 1×8192×16×96        | 12.8530       | 16.1406   | **1.26×**   | 0.3710     | 0.1238    | 12.3712   |
| 2×16384×8×96        | 31.5028       | 37.9965   | **1.21×**   | 1.3258     | 0.6276    | 29.5778   |
| 1×32768×16×96       | 68.8183       | 79.2246   | **1.15×**   | 5.1454     | 3.1332    | 60.8095   |
| 2×8192×8×96         | 13.5406       | 17.1950   | **1.27×**   | 0.3718     | 0.1236    | 13.0513   |
| 4×4096×16×384       | 28.3438       | 41.3379   | **1.46×**   | 0.3720     | 0.1761    | 27.7693   |
| 4×4096×16×256       | 21.5160       | 28.9681   | **1.35×**   | 0.3711     | 0.1762    | 20.9829   |

------
## 2. Prefill — FP8

### Benchmark Results

| Shape `[B,S,KVH,H]` | flag_attn(ms) | vLLM (ms) | vLLM / ours | Score (ms) | TopK (ms) | Attn (ms) |
| ------------------- | ------------- | --------- | ----------- | ---------- | --------- | --------- |
| 1×8192×16×96        | 17.3029       | 26.2415   | **1.52×**   | 0.2023     | 0.1236    | 16.9745   |
| 2×16384×8×96        | 42.7100       | 71.0890   | **1.66×**   | 0.7141     | 0.6323    | 41.3461   |
| 1×32768×16×96       | 79.8781       | 117.9459  | **1.48×**   | 2.7282     | 3.1327    | 74.1841   |
| 2×8192×8×96         | 19.8213       | 33.2899   | **1.68×**   | 0.2025     | 0.1236    | 19.4617   |
| 4×4096×16×384       | 49.4060       | 80.0902   | **1.62×**   | 0.1941     | 0.1761    | 48.9741   |
| 4×4096×16×256       | 34.3683       | 57.3066   | **1.67×**   | 0.1941     | 0.1761    | 33.9236   |

------

## 3. Decode — BF16

### Benchmark Results

| Shape `[B,S,KVH,H]` | flag_attn(ms) | vLLM (ms) | vLLM / ours | IdxDec (ms) | AttnDec (ms) |
| ------------------- | ------------- | --------- | ----------- | ----------- | ------------ |
| 1×4096×16×96        | 0.2225        | 0.2102    | **0.94×**   | 0.1043      | 0.0428       |
| 1×16384×16×96       | 0.2104        | 0.2090    | **0.99×**   | 0.1048      | 0.0420       |
| 1×65536×16×96       | 0.2115        | 0.2091    | **0.99×**   | 0.1066      | 0.0422       |
| 4×4096×8×96         | 0.2133        | 0.2117    | **0.99×**   | 0.1027      | 0.0430       |
| 4×16384×8×96        | 0.2128        | 0.2111    | **0.99×**   | 0.1044      | 0.0427       |
| 16×4096×8×96        | 0.2166        | 0.2178    | **1.01×**   | 0.1029      | 0.0644       |
| 32×2048×4×48        | 0.0870        | 0.2204    | **2.53×**   | 0.0055      | 0.0641       |
| 64×1024×4×48        | 0.0878        | 0.2177    | **2.48×**   | 0.0059      | 0.0660       |

------

## 4. Decode — FP8

### Benchmark Results

| Shape `[B,S,KVH,H]` | flag_attn(ms) | vLLM (ms) | vLLM / ours | IdxDec (ms) | AttnDec (ms) |
| ------------------- | ------------- | --------- | ----------- | ----------- | ------------ |
| 1×4096×16×96        | 0.2164        | 0.2124    | **0.98×**   | 0.1025      | 0.0443       |
| 1×16384×16×96       | 0.2099        | 0.2100    | **1.00×**   | 0.1033      | 0.0433       |
| 1×65536×16×96       | 0.2113        | 0.2105    | **1.00×**   | 0.1032      | 0.0437       |
| 4×4096×8×96         | 0.2215        | 0.2148    | **0.97×**   | 0.1053      | 0.0454       |
| 4×16384×8×96        | 0.2175        | 0.2186    | **1.01×**   | 0.1056      | 0.0455       |
| 16×4096×8×96        | 0.2221        | 0.2268    | **1.02×**   | 0.1032      | 0.0595       |
| 32×2048×4×48        | 0.0900        | 0.2268    | **2.52×**   | 0.0056      | 0.0597       |
| 64×1024×4×48        | 0.0942        | 0.2238    | **2.38×**   | 0.0056      | 0.0617       |

------

## Test Status

```text
PASSED
```

Note: When topk=32, the decode stage can achieve better performance.



```python
pytest -vv -s tests/flag_attn/test_minimax_sparse_attention.py 

pytest -vv -s benchmark/minimax_sparse_attention_benchmark.py 

``` 