### PR TITLE
ci: publish release packages to FlagOS Nexus via the shared build-infra workflow

### DIFF
--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -1,0 +1,26 @@
+# Publish the deb/rpm artifacts of a release tag to the FlagOS Nexus
+# repositories through the shared workflow in flagos-ai/build-infra.
+#
+# The shared workflow waits for build-deb.yml (required) and build-rpm.yml
+# (optional) of the same commit, downloads their artifacts, uploads them, and
+# fails loudly if nothing could be uploaded. Pre-release tags (rc/alpha/beta/
+# dev) are skipped by its guard job; workflow_dispatch always publishes and
+# accepts an explicit build run id.
+name: Upload to Nexus Repository
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Build workflow run ID (optional, uses latest successful run if blank)'
+        required: false
+
+jobs:
+  upload:
+    uses: flagos-ai/build-infra/.github/workflows/upload-nexus.yml@main
+    with:
+      run_id: ${{ github.event.inputs.run_id }}
+    secrets: inherit


### PR DESCRIPTION
## Why

`build-deb.yml` / `build-rpm.yml` (#31) produce packages on every `v*` tag, but nothing publishes them: `v0.3.0` built green on 06-24 and the artifacts simply expired after 7 days. FlagOS Nexus currently holds no FlagAttention package.

## What

Adds `.github/workflows/upload-nexus.yml`, a thin caller of the shared [`flagos-ai/build-infra/.github/workflows/upload-nexus.yml`](https://github.com/flagos-ai/build-infra/blob/main/.github/workflows/upload-nexus.yml) — identical to the one libtriton_jit already uses. The shared workflow:

- skips pre-release tags (`rc`/`a`/`b`/`dev`) on `push`, always publishes on `workflow_dispatch`
- waits for `build-deb.yml` (required) and `build-rpm.yml` (optional) of the same commit, downloads their artifacts
- uploads deb → `flagos-apt-hosted`, rpm → `flagos-yum-hosted` using the org-level `NEXUS_TOKEN`
- fails the job if packages were found but none uploaded

No change to the build workflows. After merge, the existing `v0.3.0` can be published with a manual dispatch (rebuild + upload) without re-tagging.

Part of FEP-0019 Wave 1 (flagos-ai/community#59).